### PR TITLE
added: call `getinfo` when debug logging is activated and not solved

### DIFF
--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -114,7 +114,7 @@ julia> round.(getinfo(mpc)[:Ŷ], digits=3)
 function getinfo(mpc::PredictiveController{NT}) where NT<:Real
     model    = mpc.estim.model
     nŶe, nUe = (mpc.Hp+1)*model.ny, (mpc.Hp+1)*model.nu 
-    info = Dict{Symbol, Union{JuMP._SolutionSummary, Vector{NT}, NT}}()
+    info = Dict{Symbol, Any}()
     Ŷ0, u0, û0  = similar(mpc.Yop), similar(model.uop), similar(model.uop)
     Ŷs          = similar(mpc.Yop)
     x̂0, x̂0next  = similar(mpc.estim.x̂0), similar(mpc.estim.x̂0)

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -519,13 +519,22 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     if !issolved(optim)
         status = JuMP.termination_status(optim)
         if iserror(optim)
-            @error("MPC terminated without solution: returning last solution shifted", 
-                   status)
+            @error(
+                "MPC terminated without solution: estimation in open-loop "*
+                "(more info in debug log)",
+                status
+            )
         else
-            @warn("MPC termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
-                  "solution anyway", status)
+            @warn(
+                "MPC termination status not OPTIMAL or LOCALLY_SOLVED: keeping solution "*
+                "anyway (more info in debug log)", 
+                status
+            )
         end
-        @debug("The function getinfo returns: ", getinfo(mpc))
+        @debug(
+            "calling getinfo (use logger with show_limited=false if values are truncated)", 
+            getinfo(estim)
+        )
     end
     if iserror(optim)
         mpc.ΔŨ .= ΔŨ0

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -525,7 +525,7 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
             @warn("MPC termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
                   "solution anyway", status)
         end
-        @debug getinfo(mpc)
+        @debug("The function getinfo returns: ", getinfo(mpc))
     end
     if iserror(optim)
         mpc.ΔŨ .= ΔŨ0

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -491,7 +491,8 @@ If supported by `mpc.optim`, it warm-starts the solver at:
 where ``\mathbf{Δu}_{k-1}(k+j)`` is the input increment for time ``k+j`` computed at the 
 last control period ``k-1``. It then calls `JuMP.optimize!(mpc.optim)` and extract the
 solution. A failed optimization prints an `@error` log in the REPL and returns the 
-warm-start value.
+warm-start value. A failed optimization also prints [`getinfo`](@ref) results in
+the debug log [if activated](https://docs.julialang.org/en/v1/stdlib/Logging/#Example:-Enable-debug-level-messages).
 """
 function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     model, optim = mpc.estim.model, mpc.optim

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -524,7 +524,7 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
             @warn("MPC termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
                   "solution anyway", status)
         end
-        @debug JuMP.solution_summary(optim, verbose=true)
+        @debug getinfo(mpc)
     end
     if iserror(optim)
         mpc.ΔŨ .= ΔŨ0

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -533,7 +533,7 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
         end
         @debug(
             "calling getinfo (use logger with show_limited=false if values are truncated)", 
-            getinfo(estim)
+            getinfo(mpc)
         )
     end
     if iserror(optim)

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -108,8 +108,7 @@ function getinfo(estim::MovingHorizonEstimator{NT}) where NT<:Real
     nu, ny, nd = model.nu, model.ny, model.nd
     nx̂, nym, nŵ, nϵ = estim.nx̂, estim.nym, estim.nx̂, estim.nϵ
     nx̃ = nϵ + nx̂
-    MyTypes = Union{JuMP._SolutionSummary, Hermitian{NT, Matrix{NT}}, Vector{NT}, NT}
-    info = Dict{Symbol, MyTypes}()
+    info = Dict{Symbol, Any}()
     V̂,  X̂0 = similar(estim.Y0m[1:nym*Nk]), similar(estim.X̂0[1:nx̂*Nk])
     û0, ŷ0 = similar(model.uop), similar(model.yop)
     V̂,  X̂0 = predict!(V̂, X̂0, û0, ŷ0, estim, model, estim.Z̃)

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -412,7 +412,7 @@ function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
             @warn("MHE termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
                   "solution anyway", status)
         end
-        @debug getinfo(estim)
+        @debug("The function getinfo returns: ", getinfo(estim))
     end
     if iserror(optim)
         estim.Z̃ .= Z̃_0

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -369,7 +369,8 @@ If supported by `estim.optim`, it warm-starts the solver at:
 where ``\mathbf{ŵ}_{k-1}(k-j)`` is the input increment for time ``k-j`` computed at the 
 last time step ``k-1``. It then calls `JuMP.optimize!(estim.optim)` and extract the
 solution. A failed optimization prints an `@error` log in the REPL and returns the 
-warm-start value.
+warm-start value. A failed optimization also prints [`getinfo`](@ref) results in
+the debug log [if activated](https://docs.julialang.org/en/v1/stdlib/Logging/#Example:-Enable-debug-level-messages).
 """
 function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
     model, optim = estim.model, estim.optim

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -411,7 +411,7 @@ function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
             @warn("MHE termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
                   "solution anyway", status)
         end
-        @debug JuMP.solution_summary(optim, verbose=true)
+        @debug getinfo(estim)
     end
     if iserror(optim)
         estim.Z̃ .= Z̃_0

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -406,13 +406,22 @@ function optim_objective!(estim::MovingHorizonEstimator{NT}) where NT<:Real
     if !issolved(optim)
         status = JuMP.termination_status(optim)
         if iserror(optim)
-            @error("MHE terminated without solution: estimation in open-loop", 
-                   status)
+            @error(
+                "MHE terminated without solution: estimation in open-loop "*
+                "(more info in debug log)",
+                status
+            )
         else
-            @warn("MHE termination status not OPTIMAL or LOCALLY_SOLVED: keeping "*
-                  "solution anyway", status)
+            @warn(
+                "MHE termination status not OPTIMAL or LOCALLY_SOLVED: keeping solution "*
+                "anyway (more info in debug log)", 
+                status
+            )
         end
-        @debug("The function getinfo returns: ", getinfo(estim))
+        @debug(
+            "calling getinfo (use logger with show_limited=false if values are truncated)", 
+            getinfo(estim)
+        )
     end
     if iserror(optim)
         estim.Z̃ .= Z̃_0


### PR DESCRIPTION
Applies to `LinearMPC`, `NonLinMPC` and `MovingHorizonEstimator`
`getinfo` is an expensive function but as mentioned in the [doc](https://docs.julialang.org/en/v1/stdlib/Logging/#man-logging), the function is not called at all when debug logging is disabled.

It can be useful to get additionnal context in github CI. It theoretically allows the user to save the debug logging with full context in a separate file.

Before this change, I was only showing `JuMP.solution_summary` in the debug log. 