### PR TITLE
Minor doc corrections + allow `LinModel` linearization

### DIFF
--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -343,7 +343,7 @@ They are defined in the Extended Help section.
     \mathbf{E}   &= [\begin{smallmatrix}\mathbf{0} & \mathbf{E^†} \end{smallmatrix}]    \\
     \mathbf{E^†} &= \text{diag}\mathbf{(Ĉ,Ĉ,...,Ĉ)}                                     \\
     \mathbf{J}   &= \text{diag}\mathbf{(D̂_d,D̂_d,...,D̂_d)}                               \\
-    \mathbf{ex̂}  &= [\begin{smallmatrix}\mathbf{0} & \mathbf{I}\end{smallmatrix}]   
+    \mathbf{e_x̂} &= [\begin{smallmatrix}\mathbf{0} & \mathbf{I}\end{smallmatrix}]   
     \end{aligned}
     ```
 """

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -118,6 +118,17 @@ end
     @test_throws DimensionMismatch evaloutput(linmodel1, zeros(1))
 end
 
+@testitem "LinModel linearization" setup=[SetupMPCtests] begin
+    using .SetupMPCtests
+    linmodel1 = LinModel(sys, Ts, i_d=[3])
+    linmodel2 = linearize(linmodel1, x=[1,2,3,4], u=[5,6], d=[7])
+    @test linmodel2.A ≈ linmodel1.A
+    @test linmodel2.Bu ≈ linmodel1.Bu
+    @test linmodel2.Bd ≈ linmodel1.Bd
+    @test linmodel2.C ≈ linmodel1.C
+    @test linmodel2.Dd ≈ linmodel1.Dd
+end
+
 @testitem "LinModel real time simulations" setup=[SetupMPCtests] begin
     using .SetupMPCtests, ControlSystemsBase, LinearAlgebra
     linmodel1 = LinModel(tf(2, [10, 1]), 0.25)


### PR DESCRIPTION
Yes, this is quite useless to linearize an already linear model. 
It's only for the consistency among `SimModel` types.