### PR TITLE
new `ManualEstimator` tests and minor doc corrections

### DIFF
--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -105,8 +105,8 @@ The controller minimizes the following objective function at each discrete time 
 See [`LinMPC`](@ref) for the variable definitions. This controller does not support
 constraints but the computational costs are extremely low (array division), therefore 
 suitable for applications that require small sample times. The keyword arguments are
-identical to [`LinMPC`](@ref), except for `Cwt` and `optim` which are not supported. This
-controller uses a [`SingleShooting`](@ref) transcription method.
+identical to [`LinMPC`](@ref), except for `Cwt`, `transcription` and `optim`, which are not
+supported. This controller uses a [`SingleShooting`](@ref) transcription method.
 
 This method uses the default state estimator, a [`SteadyKalmanFilter`](@ref) with default
 arguments. This controller is allocation-free.

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -70,7 +70,7 @@ unmeasured ``\mathbf{y^u}``. `model` evaluates the deterministic predictions
 ``\mathbf{ŷ_d}``, and `stoch_ym`, the stochastic predictions of the measured outputs 
 ``\mathbf{ŷ_s^m}`` (the unmeasured ones being ``\mathbf{ŷ_s^u=0}``). The predicted outputs
 sum both values : ``\mathbf{ŷ = ŷ_d + ŷ_s}``. See the Extended Help for more details. This
-estimator is allocation-free is `model` simulations do not allocate.
+estimator is allocation-free if `model` simulations do not allocate.
 
 !!! warning
     `InternalModel` estimator does not work if `model` is integrating or unstable. The 


### PR DESCRIPTION
Added an integration test with `ManualEstimator` with an external state estimators. The comparison is done with the default setup, that is the built-in `SteadyKalmanFilter` for linear models, and `UnscentedKalmanFilter`, for nonlinear models.