### PR TITLE
added: new `KalmanCovariance` struct to handle covariance sparsity efficiently

### DIFF
--- a/src/ModelPredictiveControl.jl
+++ b/src/ModelPredictiveControl.jl
@@ -54,7 +54,7 @@ include("plot_sim.jl")
     @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
-        include("precompile.jl")
+    #    include("precompile.jl")
     end
 end
 

--- a/src/ModelPredictiveControl.jl
+++ b/src/ModelPredictiveControl.jl
@@ -54,7 +54,7 @@ include("plot_sim.jl")
     @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
-    #    include("precompile.jl")
+        include("precompile.jl")
     end
 end
 

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -94,6 +94,27 @@ function ControllerWeights(
     return ControllerWeights{NT}(NT.(M_Hp), NT.(N_Hc), NT.(L_Hp), Cwt, Ewt)
 end
 
+"Validate predictive controller weight and horizon specified values."
+function validate_weights(model, Hp, Hc, M_Hp, N_Hc, L_Hp, C=Inf, E=nothing)
+    nu, ny = model.nu, model.ny
+    nM, nN, nL = ny*Hp, nu*Hc, nu*Hp
+    Hp < 1  && throw(ArgumentError("Prediction horizon Hp should be ≥ 1"))
+    Hc < 1  && throw(ArgumentError("Control horizon Hc should be ≥ 1"))
+    Hc > Hp && throw(ArgumentError("Control horizon Hc should be ≤ prediction horizon Hp"))
+    size(M_Hp) ≠ (nM,nM) && throw(ArgumentError("M_Hp size $(size(M_Hp)) ≠ (ny*Hp, ny*Hp) ($nM,$nM)"))
+    size(N_Hc) ≠ (nN,nN) && throw(ArgumentError("N_Hc size $(size(N_Hc)) ≠ (nu*Hc, nu*Hc) ($nN,$nN)"))
+    size(L_Hp) ≠ (nL,nL) && throw(ArgumentError("L_Hp size $(size(L_Hp)) ≠ (nu*Hp, nu*Hp) ($nL,$nL)"))
+    (isdiag(M_Hp) && any(diag(M_Hp) .< 0)) && throw(ArgumentError("Mwt values should be nonnegative"))
+    (isdiag(N_Hc) && any(diag(N_Hc) .< 0)) && throw(ArgumentError("Nwt values should be nonnegative"))
+    (isdiag(L_Hp) && any(diag(L_Hp) .< 0)) && throw(ArgumentError("Lwt values should be nonnegative"))
+    !ishermitian(M_Hp) && throw(ArgumentError("M_Hp should be hermitian"))
+    !ishermitian(N_Hc) && throw(ArgumentError("N_Hc should be hermitian"))
+    !ishermitian(L_Hp) && throw(ArgumentError("L_Hp should be hermitian"))
+    size(C) ≠ ()    && throw(ArgumentError("Cwt should be a real scalar"))
+    C < 0           && throw(ArgumentError("Cwt weight should be ≥ 0"))
+    !isnothing(E) && size(E) ≠ () && throw(ArgumentError("Ewt should be a real scalar"))
+end
+
 "Include all the data for the constraints of [`PredictiveController`](@ref)"
 struct ControllerConstraint{NT<:Real, GCfunc<:Union{Nothing, Function}}
     # matrices for the terminal constraints:
@@ -867,25 +888,4 @@ end
 "Return empty matrices if `estim` is not a [`InternalModel`](@ref)."
 function init_stochpred(estim::StateEstimator{NT}, _ ) where NT<:Real
     return zeros(NT, 0, estim.nxs), zeros(NT, 0, estim.model.ny)
-end
-
-"Validate predictive controller weight and horizon specified values."
-function validate_weights(model, Hp, Hc, M_Hp, N_Hc, L_Hp, C=Inf, E=nothing)
-    nu, ny = model.nu, model.ny
-    nM, nN, nL = ny*Hp, nu*Hc, nu*Hp
-    Hp < 1  && throw(ArgumentError("Prediction horizon Hp should be ≥ 1"))
-    Hc < 1  && throw(ArgumentError("Control horizon Hc should be ≥ 1"))
-    Hc > Hp && throw(ArgumentError("Control horizon Hc should be ≤ prediction horizon Hp"))
-    size(M_Hp) ≠ (nM,nM) && throw(ArgumentError("M_Hp size $(size(M_Hp)) ≠ (ny*Hp, ny*Hp) ($nM,$nM)"))
-    size(N_Hc) ≠ (nN,nN) && throw(ArgumentError("N_Hc size $(size(N_Hc)) ≠ (nu*Hc, nu*Hc) ($nN,$nN)"))
-    size(L_Hp) ≠ (nL,nL) && throw(ArgumentError("L_Hp size $(size(L_Hp)) ≠ (nu*Hp, nu*Hp) ($nL,$nL)"))
-    (isdiag(M_Hp) && any(diag(M_Hp) .< 0)) && throw(ArgumentError("Mwt values should be nonnegative"))
-    (isdiag(N_Hc) && any(diag(N_Hc) .< 0)) && throw(ArgumentError("Nwt values should be nonnegative"))
-    (isdiag(L_Hp) && any(diag(L_Hp) .< 0)) && throw(ArgumentError("Lwt values should be nonnegative"))
-    !ishermitian(M_Hp) && throw(ArgumentError("M_Hp should be hermitian"))
-    !ishermitian(N_Hc) && throw(ArgumentError("N_Hc should be hermitian"))
-    !ishermitian(L_Hp) && throw(ArgumentError("L_Hp should be hermitian"))
-    size(C) ≠ ()    && throw(ArgumentError("Cwt should be a real scalar"))
-    C < 0           && throw(ArgumentError("Cwt weight should be ≥ 0"))
-    !isnothing(E) && size(E) ≠ () && throw(ArgumentError("Ewt should be a real scalar"))
 end

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -91,7 +91,8 @@ function ControllerWeights(
         model::SimModel{NT}, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt=Inf, Ewt=0
     ) where {NT<:Real}
     validate_weights(model, Hp, Hc, M_Hp, N_Hc, L_Hp, Cwt, Ewt)
-    return ControllerWeights{NT}(NT.(M_Hp), NT.(N_Hc), NT.(L_Hp), Cwt, Ewt)
+    M_Hp, N_Hc, L_Hp = NT.(M_Hp), NT.(N_Hc), NT.(L_Hp)
+    return ControllerWeights{NT}(M_Hp, N_Hc, L_Hp, Cwt, Ewt)
 end
 
 "Validate predictive controller weight and horizon specified values."

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -535,12 +535,12 @@ prediction horizon ``H_p``.
 ```jldoctest
 julia> mpc = LinMPC(KalmanFilter(LinModel(ss(0.1, 0.5, 1, 0, 4.0)), σR=[√25]), Hp=1, Hc=1);
 
-julia> mpc.estim.model.A[1], mpc.estim.R̂[1], mpc.weights.M_Hp[1], mpc.weights.Ñ_Hc[1]
+julia> mpc.estim.model.A[1], mpc.estim.cov.R̂[1], mpc.weights.M_Hp[1], mpc.weights.Ñ_Hc[1]
 (0.1, 25.0, 1.0, 0.1)
 
 julia> setmodel!(mpc, LinModel(ss(0.42, 0.5, 1, 0, 4.0)); R̂=[9], M_Hp=[10], Nwt=[0.666]);
 
-julia> mpc.estim.model.A[1], mpc.estim.R̂[1], mpc.weights.M_Hp[1], mpc.weights.Ñ_Hc[1]
+julia> mpc.estim.model.A[1], mpc.estim.cov.R̂[1], mpc.weights.M_Hp[1], mpc.weights.Ñ_Hc[1]
 (0.42, 9.0, 10.0, 0.666)
 ```
 """

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -64,9 +64,33 @@ struct KalmanCovariances{
         R̂   = Hermitian(R̂, :L)
         # the following variables are only for the moving horizon estimator:
         invP̄, invQ̂, invR̂ = copy(P̂_0), copy(Q̂), copy(R̂)
-        inv!(invP̄)
-        inv!(invQ̂)
-        inv!(invR̂)
+        try
+            inv!(invP̄)
+        catch err
+            if err isa PosDefException
+                error("P̂_0 is not positive definite")
+            else
+                rethrow()
+            end
+        end
+        try
+            inv!(invQ̂)
+        catch err
+            if err isa PosDefException
+                error("Q̂ is not positive definite")
+            else
+                rethrow()
+            end
+        end
+        try
+            inv!(invR̂)
+        catch err
+            if err isa PosDefException
+                error("R̂ is not positive definite")
+            else
+                rethrow()
+            end
+        end
         invQ̂_He = repeatdiag(invQ̂, He)
         invR̂_He = repeatdiag(invR̂, He)
         invQ̂_He = Hermitian(invQ̂_He, :L)
@@ -80,7 +104,7 @@ function KalmanCovariances(
         model::SimModel{NT}, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing, He=1
     ) where {NT<:Real}
     validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
-    return KalmanCovariances{NT}(model, i_ym, nint_u, nint_ym, NT.(Q̂), NT.(R̂), P̂_0, He)
+    return KalmanCovariances{NT}(model, i_ym, nint_u, nint_ym, NT.(Q̂), NT.(R̂), NT.(P̂_0), He)
 end
 
 """

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -70,8 +70,6 @@ struct KalmanCovariances{
         inv!(invR̂)
         invQ̂_He = repeatdiag(invQ̂, He)
         invR̂_He = repeatdiag(invR̂, He)
-        isdiag(invQ̂_He) && (invQ̂_He = Diagonal(invQ̂_He)) # Q̂C(invQ̂_He) does not work on Julia 1.10
-        isdiag(invR̂_He) && (invR̂_He = Diagonal(invR̂_He)) # R̂C(invR̂_He) does not work on Julia 1.10
         invQ̂_He = Hermitian(invQ̂_He, :L)
         invR̂_He = Hermitian(invR̂_He, :L)
         return new{NT, Q̂C, R̂C}(P̂_0, P̂, Q̂, R̂, invP̄, invQ̂_He, invR̂_He)

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -105,7 +105,12 @@ function KalmanCovariances(
     ) where {NT<:Real}
     validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
     Q̂, R̂ = NT.(Q̂), NT.(R̂)
-    !isnothing(P̂_0) && (P̂_0 .= NT.(P̂_0))
+    if !isnothing(P̂_0) 
+        P̂_0 .= NT.(P̂_0)
+    end
+    println(Q̂)
+    println(R̂)
+    println(P̂_0)
     return KalmanCovariances{NT}(Q̂, R̂, P̂_0, He)
 end
 

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -105,12 +105,7 @@ function KalmanCovariances(
     ) where {NT<:Real}
     validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
     Q̂, R̂ = NT.(Q̂), NT.(R̂)
-    if !isnothing(P̂_0) 
-        P̂_0 .= NT.(P̂_0)
-    end
-    println(Q̂)
-    println(R̂)
-    println(P̂_0)
+    !isnothing(P̂_0) && (P̂_0 = NT.(P̂_0))
     return KalmanCovariances{NT}(Q̂, R̂, P̂_0, He)
 end
 

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -38,6 +38,73 @@ function StateEstimatorBuffer{NT}(
     return StateEstimatorBuffer{NT}(u, û, k, x̂, P̂, Q̂, R̂, K̂, ym, ŷ, d, empty)
 end
 
+"Include all the covariance matrices for the Kalman filters and moving horizon estimator."
+struct KalmanCovariances{
+    NT<:Real,
+    # parameters to support both dense and Diagonal matrices (with specialization):
+    Q̂C<:AbstractMatrix{NT},
+    R̂C<:AbstractMatrix{NT},
+}
+    P̂_0::Hermitian{NT, Matrix{NT}}
+    P̂::Hermitian{NT, Matrix{NT}}
+    Q̂::Hermitian{NT, Q̂C}
+    R̂::Hermitian{NT, R̂C}
+    invP̄::Hermitian{NT, Matrix{NT}}
+    invQ̂_He::Hermitian{NT, Q̂C}
+    invR̂_He::Hermitian{NT, R̂C}
+    function KalmanCovariances{NT}(
+        model, i_ym, nint_u, nint_ym, Q̂::Q̂C, R̂::R̂C, P̂_0=nothing, He=1
+    ) where {NT<:Real, Q̂C<:AbstractMatrix{NT}, R̂C<:AbstractMatrix{NT}}
+        validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
+        if isnothing(P̂_0)
+            P̂_0 = zeros(NT, 0, 0)
+        end
+        P̂_0 = Hermitian(P̂_0, :L)
+        P̂   = copy(P̂_0)
+        Q̂   = Hermitian(Q̂, :L)
+        R̂   = Hermitian(R̂, :L)
+        # the following variables are only for the moving horizon estimator:
+        invP̄, invQ̂, invR̂ = copy(P̂_0), copy(Q̂), copy(R̂)
+        inv!(invP̄)
+        inv!(invQ̂)
+        inv!(invR̂)
+        invQ̂_He = repeatdiag(invQ̂, He)
+        invR̂_He = repeatdiag(invR̂, He)
+        isdiag(invQ̂_He) && (invQ̂_He = Diagonal(invQ̂_He)) # Q̂C(invQ̂_He) does not work on Julia 1.10
+        isdiag(invR̂_He) && (invR̂_He = Diagonal(invR̂_He)) # R̂C(invR̂_He) does not work on Julia 1.10
+        invQ̂_He = Hermitian(invQ̂_He, :L)
+        invR̂_He = Hermitian(invR̂_He, :L)
+        return new{NT, Q̂C, R̂C}(P̂_0, P̂, Q̂, R̂, invP̄, invQ̂_He, invR̂_He)
+    end
+end
+
+"Outer constructor to convert covariance matrix number type to `NT` if necessary."
+function KalmanCovariances(
+        model::SimModel{NT}, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing, He=1
+    ) where {NT<:Real}
+    return KalmanCovariances{NT}(model, i_ym, nint_u, nint_ym, NT.(Q̂), NT.(R̂), P̂_0, He)
+end
+
+"""
+    validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing)
+
+Validate sizes and Hermitianity of process `Q̂`` and sensor `R̂` noises covariance matrices.
+
+Also validate initial estimate covariance `P̂_0`, if provided.
+"""
+function validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing)
+    nym = length(i_ym)
+    nx̂  = model.nx + sum(nint_u) + sum(nint_ym)
+    size(Q̂)  ≠ (nx̂, nx̂)     && error("Q̂ size $(size(Q̂)) ≠ nx̂, nx̂ $((nx̂, nx̂))")
+    !ishermitian(Q̂)         && error("Q̂ is not Hermitian")
+    size(R̂)  ≠ (nym, nym)   && error("R̂ size $(size(R̂)) ≠ nym, nym $((nym, nym))")
+    !ishermitian(R̂)         && error("R̂ is not Hermitian")
+    if ~isnothing(P̂_0)
+        size(P̂_0) ≠ (nx̂, nx̂) && error("P̂_0 size $(size(P̂_0)) ≠ nx̂, nx̂ $((nx̂, nx̂))")
+        !ishermitian(P̂_0)    && error("P̂_0 is not Hermitian")
+    end
+end
+
 @doc raw"""
     init_estimstoch(model, i_ym, nint_u, nint_ym) -> As, Cs_u, Cs_y, nxs, nint_u, nint_ym
 

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -55,7 +55,6 @@ struct KalmanCovariances{
     function KalmanCovariances{NT}(
         model, i_ym, nint_u, nint_ym, Q̂::Q̂C, R̂::R̂C, P̂_0=nothing, He=1
     ) where {NT<:Real, Q̂C<:AbstractMatrix{NT}, R̂C<:AbstractMatrix{NT}}
-        validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
         if isnothing(P̂_0)
             P̂_0 = zeros(NT, 0, 0)
         end
@@ -76,10 +75,11 @@ struct KalmanCovariances{
     end
 end
 
-"Outer constructor to convert covariance matrix number type to `NT` if necessary."
+"Outer constructor to validate and convert covariance matrices if necessary."
 function KalmanCovariances(
         model::SimModel{NT}, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing, He=1
     ) where {NT<:Real}
+    validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
     return KalmanCovariances{NT}(model, i_ym, nint_u, nint_ym, NT.(Q̂), NT.(R̂), P̂_0, He)
 end
 

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -53,7 +53,7 @@ struct KalmanCovariances{
     invQ̂_He::Hermitian{NT, Q̂C}
     invR̂_He::Hermitian{NT, R̂C}
     function KalmanCovariances{NT}(
-        model, i_ym, nint_u, nint_ym, Q̂::Q̂C, R̂::R̂C, P̂_0=nothing, He=1
+        Q̂::Q̂C, R̂::R̂C, P̂_0, He
     ) where {NT<:Real, Q̂C<:AbstractMatrix{NT}, R̂C<:AbstractMatrix{NT}}
         if isnothing(P̂_0)
             P̂_0 = zeros(NT, 0, 0)
@@ -104,7 +104,9 @@ function KalmanCovariances(
         model::SimModel{NT}, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0=nothing, He=1
     ) where {NT<:Real}
     validate_kfcov(model, i_ym, nint_u, nint_ym, Q̂, R̂, P̂_0)
-    return KalmanCovariances{NT}(model, i_ym, nint_u, nint_ym, NT.(Q̂), NT.(R̂), NT.(P̂_0), He)
+    Q̂, R̂ = NT.(Q̂), NT.(R̂)
+    !isnothing(P̂_0) && (P̂_0 .= NT.(P̂_0))
+    return KalmanCovariances{NT}(Q̂, R̂, P̂_0, He)
 end
 
 """

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -375,12 +375,12 @@ augmented model is not verified (see Extended Help for more info).
 ```jldoctest
 julia> kf = KalmanFilter(LinModel(ss(0.1, 0.5, 1, 0, 4.0)), σQ=[√4.0], σQint_ym=[√0.25]);
 
-julia> kf.model.A[], kf.Q̂[1, 1], kf.Q̂[2, 2] 
+julia> kf.model.A[], kf.cov.Q̂[1, 1], kf.cov.Q̂[2, 2] 
 (0.1, 4.0, 0.25)
 
 julia> setmodel!(kf, LinModel(ss(0.42, 0.5, 1, 0, 4.0)), Q̂=[1 0;0 0.5]);
 
-julia> kf.model.A[], kf.Q̂[1, 1], kf.Q̂[2, 2] 
+julia> kf.model.A[], kf.cov.Q̂[1, 1], kf.cov.Q̂[2, 2] 
 (0.42, 1.0, 0.5)
 ```
 

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -112,7 +112,7 @@ removes the operating points with [`remove_op!`](@ref) and call [`init_estimate!
   bumpless manual to automatic transfer. See [`init_estimate!`](@ref) for details.
 - Else, `estim.x̂0` is left unchanged. Use [`setstate!`](@ref) to manually modify it.
 
-If applicable, it also sets the error covariance `estim.P̂` to `estim.P̂_0`.
+If applicable, it also sets the error covariance `estim.cov.P̂` to `estim.cov.P̂_0`.
 
 # Examples
 ```jldoctest
@@ -327,7 +327,7 @@ end
 """
     setstate!(estim::StateEstimator, x̂[, P̂]) -> estim
 
-Set `estim.x̂0` to `x̂ - estim.x̂op` from the argument `x̂`, and `estim.P̂` to `P̂` if applicable. 
+Set `estim.x̂0` to `x̂ - estim.x̂op` from the argument `x̂`, and `estim.cov.P̂` to `P̂` if applicable. 
 
 The covariance error estimate `P̂` can be set only if `estim` is a [`StateEstimator`](@ref)
 that computes it.
@@ -339,11 +339,11 @@ function setstate!(estim::StateEstimator, x̂, P̂=nothing)
     return estim
 end
 
-"Set the covariance error estimate `estim.P̂` to `P̂`."
+"Set the covariance error estimate `estim.cov.P̂` to `P̂`."
 function setstate_cov!(estim::StateEstimator, P̂)
     if !isnothing(P̂)
         size(P̂) == (estim.nx̂, estim.nx̂) || error("P̂ size must be $((estim.nx̂, estim.nx̂))")
-        estim.P̂ .= to_hermitian(P̂)
+        estim.cov.P̂ .= to_hermitian(P̂)
     end
     return nothing
 end
@@ -449,7 +449,7 @@ function setmodel_estimator!(estim::StateEstimator, model, _ , _ , _ , Q̂, R̂)
     estim.f̂op .= f̂op
     estim.x̂0 .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
     # --- update covariance matrices ---
-    !isnothing(Q̂) && (estim.Q̂ .= to_hermitian(Q̂))
-    !isnothing(R̂) && (estim.R̂ .= to_hermitian(R̂))
+    !isnothing(Q̂) && (estim.cov.Q̂ .= to_hermitian(Q̂))
+    !isnothing(R̂) && (estim.cov.R̂ .= to_hermitian(R̂))
     return nothing
 end

--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -225,8 +225,8 @@ function init_internalmodel(As, Bs, Cs, Ds)
 end
 
 "Throw an error if P̂ != nothing."
-function setstate_cov!(estim::InternalModel, P̂)
-    P̂ == nothing || error("InternalModel does not compute an estimation covariance matrix P̂.")
+function setstate_cov!(::InternalModel, P̂)
+    isnothing(P̂) || error("InternalModel does not compute an estimation covariance matrix P̂.")
     return nothing
 end
 

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -443,7 +443,7 @@ end
 @doc raw"""
     correct_estimate!(estim::KalmanFilter, y0m, d0)
 
-Correct `estim.x̂0` and `estim.P̂` using the time-varying [`KalmanFilter`](@ref).
+Correct `estim.x̂0` and `estim.cov.P̂` using the time-varying [`KalmanFilter`](@ref).
 
 It computes the corrected state estimate ``\mathbf{x̂}_{k}(k)`` estimation covariance 
 ``\mathbf{P̂}_{k}(k)``.
@@ -456,7 +456,7 @@ end
 @doc raw"""
     update_estimate!(estim::KalmanFilter, y0m, d0, u0)
 
-Update [`KalmanFilter`](@ref) state `estim.x̂0` and estimation error covariance `estim.P̂`.
+Update [`KalmanFilter`](@ref) state `estim.x̂0` and estimation error covariance `estim.cov.P̂`.
 
 It implements the classical time-varying Kalman Filter based on the process model described
 in [`SteadyKalmanFilter`](@ref). If `estim.direct == false`, it first corrects the estimate
@@ -790,7 +790,7 @@ end
 @doc raw"""
     update_estimate!(estim::UnscentedKalmanFilter, y0m, d0, u0)
     
-Update [`UnscentedKalmanFilter`](@ref) state `estim.x̂0` and covariance estimate `estim.P̂`.
+Update [`UnscentedKalmanFilter`](@ref) state `estim.x̂0` and covariance estimate `estim.cov.P̂`.
 
 It implements the unscented Kalman Filter based on the generalized unscented transform[^3].
 See [`init_ukf`](@ref) for the definition of the constants ``\mathbf{m̂, Ŝ}`` and ``γ``. The
@@ -1107,7 +1107,7 @@ end
 @doc raw"""
     update_estimate!(estim::ExtendedKalmanFilter, y0m, d0, u0)
 
-Update [`ExtendedKalmanFilter`](@ref) state `estim.x̂0` and covariance `estim.P̂`.
+Update [`ExtendedKalmanFilter`](@ref) state `estim.x̂0` and covariance `estim.cov.P̂`.
 
 The equations are similar to [`update_estimate!(::KalmanFilter)`](@ref) but with the 
 substitutions ``\mathbf{Ĉ^m = Ĥ^m}(k)`` and ``\mathbf{Â = F̂}(k)``, the Jacobians of the
@@ -1158,7 +1158,7 @@ function update_estimate!(estim::ExtendedKalmanFilter{NT}, y0m, d0, u0) where NT
     return predict_estimate_kf!(estim, u0, d0, estim.F̂)
 end
 
-"Set `estim.P̂` to `estim.P̂_0` for the time-varying Kalman Filters."
+"Set `estim.cov.P̂` to `estim.cov.P̂_0` for the time-varying Kalman Filters."
 function init_estimate_cov!(
     estim::Union{KalmanFilter, UnscentedKalmanFilter, ExtendedKalmanFilter}, _ , _ , _
 ) 

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -1174,7 +1174,7 @@ end
 function init_estimate_cov!(
     estim::Union{KalmanFilter, UnscentedKalmanFilter, ExtendedKalmanFilter}, _ , _ , _
 ) 
-    estim.P̂ .= estim.P̂_0
+    estim.cov.P̂ .= estim.cov.P̂_0
     return nothing
 end
 
@@ -1187,8 +1187,8 @@ Allows code reuse for [`KalmanFilter`](@ref), [`ExtendedKalmanFilterKalmanFilter
 See [`update_estimate_kf!`](@ref) for more information.
 """
 function correct_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, y0m, d0, Ĉm)
-    R̂, K̂ = estim.R̂, estim.K̂
-    x̂0, P̂ = estim.x̂0, estim.P̂
+    R̂, K̂ = estim.cov.R̂, estim.K̂
+    x̂0, P̂ = estim.x̂0, estim.cov.P̂
     # in-place operations to reduce allocations:
     P̂_Ĉmᵀ = K̂
     mul!(P̂_Ĉmᵀ, P̂, Ĉm')
@@ -1213,7 +1213,7 @@ function correct_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, 
     end
     P̂corr = estim.buffer.P̂
     mul!(P̂corr, I_minus_K̂_Ĉm, P̂)
-    estim.P̂ .= Hermitian(P̂corr, :L)
+    estim.cov.P̂ .= Hermitian(P̂corr, :L)
     return nothing
 end
 
@@ -1227,8 +1227,8 @@ They predict the state `x̂` and covariance `P̂` with the same equations. See
 [`update_estimate`](@ref) methods for the equations.
 """
 function predict_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, u0, d0, Â)
-    x̂0corr, P̂corr = estim.x̂0, estim.P̂
-    Q̂ = estim.Q̂
+    x̂0corr, P̂corr = estim.x̂0, estim.cov.P̂
+    Q̂ = estim.cov.Q̂
     x̂0next, û0, k0 = estim.buffer.x̂, estim.buffer.û, estim.buffer.k
     # in-place operations to reduce allocations:
     f̂!(x̂0next, û0, k0, estim, estim.model, x̂0corr, u0, d0)
@@ -1240,6 +1240,6 @@ function predict_estimate_kf!(estim::Union{KalmanFilter, ExtendedKalmanFilter}, 
     P̂next .= Â_P̂corr_Âᵀ .+ Q̂
     x̂0next  .+= estim.f̂op .- estim.x̂op
     estim.x̂0 .= x̂0next
-    estim.P̂  .= Hermitian(P̂next, :L)
+    estim.cov.P̂  .= Hermitian(P̂next, :L)
     return nothing
 end

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -214,6 +214,12 @@ function setmodel_estimator!(estim::SteadyKalmanFilter, model, _ , _ , _ , Q̂, 
     return nothing
 end
 
+"Throw an error if P̂ != nothing."
+function setstate_cov!(::SteadyKalmanFilter, P̂)
+    isnothing(P̂) || error("SteadyKalmanFilter does not compute an estimation covariance matrix P̂.")
+    return nothing
+end
+
 @doc raw"""
     correct_estimate!(estim::SteadyKalmanFilter, y0m, d0)
 

--- a/src/estimator/luenberger.jl
+++ b/src/estimator/luenberger.jl
@@ -135,8 +135,8 @@ function update_estimate!(estim::Luenberger, y0m, d0, u0)
 end
 
 "Throw an error if P̂ != nothing."
-function setstate_cov!(estim::Luenberger, P̂)
-    P̂ == nothing || error("Luenberger does not compute an estimation covariance matrix P̂.")
+function setstate_cov!(::Luenberger, P̂)
+    isnothing(P̂) || error("Luenberger does not compute an estimation covariance matrix P̂.")
     return nothing
 end
 

--- a/src/estimator/manual.jl
+++ b/src/estimator/manual.jl
@@ -147,4 +147,10 @@ end
 
 Do nothing for [`ManualEstimator`](@ref).
 """
-update_estimate!(estim::ManualEstimator, y0m, d0, u0) = nothing
+update_estimate!(::ManualEstimator, y0m, d0, u0) = nothing
+
+"Throw an error if P̂ != nothing."
+function setstate_cov!(::ManualEstimator, P̂)
+    isnothing(P̂) || error("ManualEstimator does not compute an estimation covariance matrix P̂.")
+    return nothing
+end

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -686,8 +686,8 @@ end
 con_nonlinprog!(g, ::MovingHorizonEstimator, ::LinModel, _ , _ , _ ) = g
 
 "Throw an error if P̂ != nothing."
-function setstate_cov!(estim::MovingHorizonEstimator, P̂)
-    P̂ == nothing || error("MovingHorizonEstimator does not compute an estimation covariance matrix P̂.")
+function setstate_cov!(::MovingHorizonEstimator, P̂)
+    isnothing(P̂) || error("MovingHorizonEstimator does not compute an estimation covariance matrix P̂.")
     return nothing
 end
 

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -16,7 +16,7 @@ function init_estimate_cov!(estim::MovingHorizonEstimator, _ , d0, u0)
         estim.D0[1:estim.model.nd] .= d0
     end
     estim.lastu0 .= u0
-    # estim.P̂_0 is in fact P̂(-1|-1) is estim.direct==false, else P̂(-1|0)
+    # estim.cov.P̂_0 is in fact P̂(-1|-1) is estim.direct==false, else P̂(-1|0)
     invert_cov!(estim, estim.cov.P̂_0)
     estim.P̂arr_old  .= estim.cov.P̂_0
     estim.x̂0arr_old .= 0
@@ -793,16 +793,16 @@ function setmodel_estimator!(
     estim.x̂0arr_old     .-= x̂op
     # --- covariance matrices ---
     if !isnothing(Q̂)
-        estim.Q̂ .= to_hermitian(Q̂)
+        estim.cov.Q̂ .= to_hermitian(Q̂)
         invQ̂  = Hermitian(estim.buffer.Q̂, :L)
-        invQ̂ .= estim.Q̂
+        invQ̂ .= estim.cov.Q̂
         inv!(invQ̂)
         estim.invQ̂_He .= Hermitian(repeatdiag(invQ̂, He), :L)
     end
     if !isnothing(R̂) 
-        estim.R̂ .= to_hermitian(R̂)
+        estim.cov.R̂ .= to_hermitian(R̂)
         invR̂  = Hermitian(estim.buffer.R̂, :L)
-        invR̂ .= estim.R̂
+        invR̂ .= estim.cov.R̂
         inv!(invR̂)
         estim.invR̂_He .= Hermitian(repeatdiag(invR̂, He), :L)
     end

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -797,14 +797,14 @@ function setmodel_estimator!(
         invQ̂  = Hermitian(estim.buffer.Q̂, :L)
         invQ̂ .= estim.cov.Q̂
         inv!(invQ̂)
-        estim.invQ̂_He .= Hermitian(repeatdiag(invQ̂, He), :L)
+        estim.cov.invQ̂_He .= Hermitian(repeatdiag(invQ̂, He), :L)
     end
     if !isnothing(R̂) 
         estim.cov.R̂ .= to_hermitian(R̂)
         invR̂  = Hermitian(estim.buffer.R̂, :L)
         invR̂ .= estim.cov.R̂
         inv!(invR̂)
-        estim.invR̂_He .= Hermitian(repeatdiag(invR̂, He), :L)
+        estim.cov.invR̂_He .= Hermitian(repeatdiag(invR̂, He), :L)
     end
     return nothing
 end

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -872,9 +872,9 @@ end
     @test mhe5.nx̂ == 8
 
     mhe6 = MovingHorizonEstimator(nonlinmodel, He=5, σP_0=[1,2,3,4], σPint_ym_0=[5,6])
-    @test mhe6.P̂_0       ≈ Hermitian(diagm(Float64[1, 4, 9 ,16, 25, 36]))
+    @test mhe6.cov.P̂_0       ≈ Hermitian(diagm(Float64[1, 4, 9 ,16, 25, 36]))
     @test mhe6.P̂arr_old ≈ Hermitian(diagm(Float64[1, 4, 9 ,16, 25, 36]))
-    @test mhe6.P̂_0 !== mhe6.P̂arr_old
+    @test mhe6.cov.P̂_0 !== mhe6.P̂arr_old
 
     mhe7 = MovingHorizonEstimator(nonlinmodel, He=10)
     @test mhe7.He == 10
@@ -894,9 +894,9 @@ end
     I_2 = Matrix{Float64}(I, 2, 2)
     optim = Model(Ipopt.Optimizer)
     mhe9 = MovingHorizonEstimator(nonlinmodel, 5, 1:2, 0, [1, 1], I_6, I_6, I_2, 1e5; optim)
-    @test mhe9.P̂_0 ≈ I(6)
-    @test mhe9.Q̂ ≈ I(6)
-    @test mhe9.R̂ ≈ I(2)
+    @test mhe9.cov.P̂_0 ≈ I(6)
+    @test mhe9.cov.Q̂ ≈ I(6)
+    @test mhe9.cov.R̂ ≈ I(2)
 
     optim = JuMP.Model(optimizer_with_attributes(Ipopt.Optimizer, "nlp_scaling_max_gradient"=>1.0))
     covestim = ExtendedKalmanFilter(nonlinmodel, 1:2, 0, [1, 1], I_6, I_6, I_2)
@@ -1103,13 +1103,13 @@ end
         preparestate!(mhe, [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
-    @test mhe.invP̄ ≈ invP̄_copy
+    @test mhe.cov.invP̄ ≈ invP̄_copy
     @test_logs(
         (:error, "Arrival covariance P̄ is not positive definite: keeping the old one"), 
         updatestate!(mhe, [10, 50], [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
-    @test mhe.invP̄ ≈ invP̄_copy
+    @test mhe.cov.invP̄ ≈ invP̄_copy
     @test_logs(
         (:error, "Arrival covariance P̄ is not invertible: keeping the old one"), 
         ModelPredictiveControl.invert_cov!(mhe, Hermitian(zeros(mhe.nx̂, mhe.nx̂),:L))
@@ -1122,7 +1122,7 @@ end
         preparestate!(mhe, [50, 30], [5])
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
-    @test mhe.invP̄ ≈ invP̄_copy
+    @test mhe.cov.invP̄ ≈ invP̄_copy
     @test_logs(
         (:error, "Arrival covariance P̄ is not finite: keeping the old one"), 
         updatestate!(mhe, [10, 50], [50, 30], [5])   
@@ -1347,8 +1347,8 @@ end
     @test mhe.con.x̃0min ≈ [-1000 - 8.0]
     @test mhe.con.x̃0max ≈ [+1000 - 8.0]
     setmodel!(mhe, Q̂=[1e-3], R̂=[1e-6])
-    @test mhe.Q̂ ≈ [1e-3]
-    @test mhe.R̂ ≈ [1e-6]
+    @test mhe.cov.Q̂ ≈ [1e-3]
+    @test mhe.cov.R̂ ≈ [1e-6]
     f(x,u,d,model) = model.A*x + model.Bu*u + model.Bd*d
     h(x,d,model)   = model.C*x + model.Du*d
     nonlinmodel = NonLinModel(f, h, 10.0, 1, 1, 1, p=linmodel, solver=nothing)

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -864,8 +864,8 @@ end
     @test mhe3.nx̂ == 5
 
     mhe4 = MovingHorizonEstimator(nonlinmodel, He=5, σQ=[1,2,3,4], σQint_ym=[5, 6], σR=[7, 8])
-    @test mhe4.Q̂ ≈ Hermitian(diagm(Float64[1, 4, 9 ,16, 25, 36]))
-    @test mhe4.R̂ ≈ Hermitian(diagm(Float64[49, 64]))
+    @test mhe4.cov.Q̂ ≈ Hermitian(diagm(Float64[1, 4, 9 ,16, 25, 36]))
+    @test mhe4.cov.R̂ ≈ Hermitian(diagm(Float64[49, 64]))
     
     mhe5 = MovingHorizonEstimator(nonlinmodel, He=5, nint_ym=[2,2])
     @test mhe5.nxs == 4
@@ -1116,7 +1116,7 @@ end
     )
     mhe.P̂arr_old[1, 1] = Inf # Inf to trigger fallback
     P̂arr_old_copy = deepcopy(mhe.P̂arr_old)
-    invP̄_copy = deepcopy(mhe.invP̄)
+    invP̄_copy = deepcopy(mhe.cov.invP̄)
     @test_logs(
         (:error, "Arrival covariance P̄ is not finite: keeping the old one"), 
         preparestate!(mhe, [50, 30], [5])
@@ -1425,7 +1425,7 @@ end
     # recuperate P̂(-1|-1) exact value using the Unscented Kalman filter:
     preparestate!(ukf, [50, 30], [20])
     preparestate!(ekf, [50, 30], [20])
-    σP̂ = sqrt.(diag(ukf.P̂))
+    σP̂ = sqrt.(diag(ukf.cov.P̂))
     mhe = MovingHorizonEstimator(nonlinmodel, He=5, nint_ym=0, direct=true, σP_0=σP̂)
     updatestate!(ukf, [10, 50], [50, 30], [20])
     updatestate!(ekf, [10, 50], [50, 30], [20])

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1128,7 +1128,7 @@ end
         updatestate!(mhe, [10, 50], [50, 30], [5])   
     )
     @test mhe.P̂arr_old ≈ P̂arr_old_copy
-    @test mhe.invP̄ ≈ invP̄_copy
+    @test mhe.cov.invP̄ ≈ invP̄_copy
 end
 
 @testitem "MovingHorizonEstimator set constraints" setup=[SetupMPCtests] begin
@@ -1354,8 +1354,8 @@ end
     nonlinmodel = NonLinModel(f, h, 10.0, 1, 1, 1, p=linmodel, solver=nothing)
     mhe2 = MovingHorizonEstimator(nonlinmodel; He, nint_ym=0)
     setmodel!(mhe2, Q̂=[1e-3], R̂=[1e-6])
-    @test mhe2.Q̂ ≈ [1e-3]
-    @test mhe2.R̂ ≈ [1e-6]
+    @test mhe2.cov.Q̂ ≈ [1e-3]
+    @test mhe2.cov.R̂ ≈ [1e-6]
     @test_throws ErrorException setmodel!(mhe2, deepcopy(nonlinmodel))
 end
 

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -215,8 +215,8 @@ end
     @test initstate!(mpc1, [10, 50], [50, 30+1]) ≈ [zeros(3); [1]]
     setstate!(mpc1, [1,2,3,4], diagm(.1:.1:.4))
     @test mpc1.estim.x̂0 ≈ [1,2,3,4]
-    @test mpc1.estim.P̂  ≈ diagm(.1:.1:.4)
-    setstate!(mpc1, [0,0,0,0], mpc1.estim.P̂_0)
+    @test mpc1.estim.cov.P̂  ≈ diagm(.1:.1:.4)
+    setstate!(mpc1, [0,0,0,0], mpc1.estim.cov.P̂_0)
     preparestate!(mpc1, [50, 30])
     updatestate!(mpc1, mpc1.estim.model.uop, [50, 30])
     @test mpc1.estim.x̂0 ≈ [0,0,0,0]

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -822,7 +822,6 @@ end
     preparestate!(nmpc11, y, [0])
     moveinput!(nmpc11, [10], [0])
     ΔU_diff = diff(getinfo(nmpc11)[:U])
-    println(ΔU_diff)
     @test ΔU_diff[[2, 4, 5, 7, 8, 9]] ≈ zeros(6) atol=1e-9
 
     @test_nowarn ModelPredictiveControl.info2debugstr(info)


### PR DESCRIPTION
Similarly to #202 for the objective function weights in MPCs, a new `KalmanCovariance` parametric struct is created. First, it avoid duplicate code in the constructor of the Kalman filters. Second, two new parameters are introduced to preserve special types like `Diagonal{NT, Vector{NT}}`. It will also preserves other special types like `SparseMatrixCSC`. The performance advantages will be mainly visible for the `MovingHorizontEstimator` with nonlinear plant models, since the objective is computed with e.g. `dot(V̂, invR̂_Nk, V̂)` and the operation is faster when `invR̂_Nk` is a `Diagonal` matrix.