### PR TITLE
added: simple `TrapezoidalCollocation()` transcription method

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,11 @@ name: Benchmark
 on:
   pull_request_target:
     branches: [ main ]
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 permissions:
   pull-requests: write    # needed to post comments
 jobs:

--- a/docs/src/manual/linmpc.md
+++ b/docs/src/manual/linmpc.md
@@ -78,8 +78,9 @@ mpc = setconstraint!(mpc, ymin=[48, -Inf])
 
 in which `Hp` and `Hc` keyword arguments are respectively the predictive and control
 horizons, and `Mwt` and `Nwt`, the output setpoint tracking and move suppression weights. By
-default, [`LinMPC`](@ref) controllers use [`OSQP`](https://osqp.org/) to solve the problem,
-soft constraints on output predictions ``\mathbf{ŷ}`` to ensure feasibility, and a
+default, [`LinMPC`](@ref) controllers use [`OSQP`](https://osqp.org/) and a direct
+[`SingleShooting`](@ref) transcription method to solve the optimal control problem, soft
+constraints on output predictions ``\mathbf{ŷ}`` to ensure feasibility, and a
 [`SteadyKalmanFilter`](@ref) to estimate the plant states[^1]. An attentive reader will also
 notice that the Kalman filter estimates two additional states compared to the plant model.
 These are the integrating states for the unmeasured plant disturbances, and they are

--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -119,8 +119,10 @@ umin, umax = [-1.5], [+1.5]
 nmpc = setconstraint!(nmpc; umin, umax)
 ```
 
-The option `Cwt=Inf` disables the slack variable `ϵ` for constraint softening. We test `mpc`
-performance on `plant` by imposing an angular setpoint of 180° (inverted position):
+The option `Cwt=Inf` disables the slack variable `ϵ` for constraint softening. By default,
+[`NonLinMPC`](@ref) controllers use [`Ipopt`](https://coin-or.github.io/Ipopt/) and a direct
+[`SingleShooting`](@ref) transcription method to solve the optimal control problem. We test
+`mpc` performance on `plant` by imposing an angular setpoint of 180° (inverted position):
 
 ```@example man_nonlin
 using JuMP; unset_time_limit_sec(nmpc.optim) # hide

--- a/docs/src/public/predictive_control.md
+++ b/docs/src/public/predictive_control.md
@@ -109,3 +109,9 @@ SingleShooting
 ```@docs
 MultipleShooting
 ```
+
+### TrapezoidalMethod
+
+```@docs
+TrapezoidalMethod
+```

--- a/docs/src/public/predictive_control.md
+++ b/docs/src/public/predictive_control.md
@@ -110,8 +110,8 @@ SingleShooting
 MultipleShooting
 ```
 
-### TrapezoidalMethod
+### TrapezoidalCollocation
 
 ```@docs
-TrapezoidalMethod
+TrapezoidalCollocation
 ```

--- a/src/ModelPredictiveControl.jl
+++ b/src/ModelPredictiveControl.jl
@@ -39,7 +39,7 @@ export MovingHorizonEstimator
 export ManualEstimator
 export default_nint, initstate!
 export PredictiveController, ExplicitMPC, LinMPC, NonLinMPC, setconstraint!, moveinput!
-export TranscriptionMethod, SingleShooting, MultipleShooting, TrapezoidalMethod
+export TranscriptionMethod, SingleShooting, MultipleShooting, TrapezoidalCollocation
 export SimResult, getinfo, sim!
 
 include("general.jl")

--- a/src/ModelPredictiveControl.jl
+++ b/src/ModelPredictiveControl.jl
@@ -39,7 +39,7 @@ export MovingHorizonEstimator
 export ManualEstimator
 export default_nint, initstate!
 export PredictiveController, ExplicitMPC, LinMPC, NonLinMPC, setconstraint!, moveinput!
-export TranscriptionMethod, SingleShooting, MultipleShooting
+export TranscriptionMethod, SingleShooting, MultipleShooting, TrapezoidalMethod
 export SimResult, getinfo, sim!
 
 include("general.jl")

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -600,11 +600,11 @@ end
         ex̂, fx̂, gx̂, jx̂, kx̂, vx̂, bx̂, 
         Eŝ, Fŝ, Gŝ, Jŝ, Kŝ, Vŝ, Bŝ,
         gc!=nothing, nc=0
-    ) -> con, nϵ, P̃Δu, P̃u, Ẽ, Ẽŝ
+    ) -> con, nϵ, P̃Δu, P̃u, Ẽ
 
 Init `ControllerConstraint` struct with default parameters based on estimator `estim`.
 
-Also return `P̃Δu`, `P̃u`, `Ẽ` and `Ẽŝ` matrices for the the augmented decision vector `Z̃`.
+Also return `P̃Δu`, `P̃u` and `Ẽ` matrices for the the augmented decision vector `Z̃`.
 """
 function init_defaultcon_mpc(
     estim::StateEstimator{NT}, 
@@ -660,7 +660,7 @@ function init_defaultcon_mpc(
         C_ymin  , C_ymax , c_x̂min , c_x̂max , i_g,
         gc!     , nc
     )
-    return con, nϵ, P̃Δu, P̃u, Ẽ, Ẽŝ
+    return con, nϵ, P̃Δu, P̃u, Ẽ
 end
 
 "Repeat predictive controller constraints over prediction `Hp` and control `Hc` horizons."

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -221,7 +221,7 @@ constraints are all soft by default. See Extended Help for time-varying constrai
 julia> mpc = LinMPC(setop!(LinModel(tf(3, [30, 1]), 4), uop=[50], yop=[25]));
 
 julia> mpc = setconstraint!(mpc, umin=[0], umax=[100], Δumin=[-10], Δumax=[+10])
-LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SteadyKalmanFilter estimator and:
+LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SingleShooting transcription, SteadyKalmanFilter estimator and:
  10 prediction steps Hp
   2 control steps Hc
   1 slack variable ϵ (control constraints)

--- a/src/controller/explicitmpc.jl
+++ b/src/controller/explicitmpc.jl
@@ -50,6 +50,7 @@ struct ExplicitMPC{
         R̂y, R̂u, Tu_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
         lastu0 = zeros(NT, nu)
         transcription = SingleShooting() # explicit MPC only supports SingleShooting
+        validate_transcription(model, transcription)
         PΔu = init_ZtoΔU(estim, transcription, Hp, Hc)
         Pu, Tu = init_ZtoU(estim, transcription, Hp, Hc, nb)
         E, G, J, K, V, B = init_predmat(model, estim, transcription, Hp, Hc)

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -5,7 +5,7 @@ struct LinMPC{
     NT<:Real, 
     SE<:StateEstimator, 
     CW<:ControllerWeights,
-    TM<:TranscriptionMethod,
+    TM<:ShootingMethod,
     JM<:JuMP.GenericModel
 } <: PredictiveController{NT}
     estim::SE
@@ -54,7 +54,7 @@ struct LinMPC{
             NT<:Real, 
             SE<:StateEstimator, 
             CW<:ControllerWeights,
-            TM<:TranscriptionMethod, 
+            TM<:ShootingMethod, 
             JM<:JuMP.GenericModel
         }
         model = estim.model
@@ -71,7 +71,7 @@ struct LinMPC{
         Eŝ, Gŝ, Jŝ, Kŝ, Vŝ, Bŝ = init_defectmat(model, estim, transcription, Hp, Hc)
         # dummy vals (updated just before optimization):
         F, fx̂, Fŝ  = zeros(NT, ny*Hp), zeros(NT, nx̂), zeros(NT, nx̂*Hp)
-        con, nϵ, P̃Δu, P̃u, Ẽ, Ẽŝ = init_defaultcon_mpc(
+        con, nϵ, P̃Δu, P̃u, Ẽ = init_defaultcon_mpc(
             estim, weights, transcription,
             Hp, Hc, 
             PΔu, Pu, E, 
@@ -156,7 +156,7 @@ arguments. This controller allocates memory at each time step for the optimizati
 - `N_Hc=Diagonal(repeat(Nwt,Hc))` : positive semidefinite symmetric matrix ``\mathbf{N}_{H_c}``.
 - `L_Hp=Diagonal(repeat(Lwt,Hp))` : positive semidefinite symmetric matrix ``\mathbf{L}_{H_p}``.
 - `Cwt=1e5` : slack variable weight ``C`` (scalar), use `Cwt=Inf` for hard constraints only.
-- `transcription=SingleShooting()` : a [`TranscriptionMethod`](@ref) for the optimization.
+- `transcription=SingleShooting()` : [`SingleShooting`](@ref) or [`MultipleShooting`](@ref).
 - `optim=JuMP.Model(OSQP.MathOptInterfaceOSQP.Optimizer)` : quadratic optimizer used in
   the predictive controller, provided as a [`JuMP.Model`](@extref) object (default to 
   [`OSQP`](https://osqp.org/docs/parsers/jump.html) optimizer).
@@ -215,7 +215,7 @@ function LinMPC(
     N_Hc = Diagonal(repeat(Nwt, get_Hc(move_blocking(Hp, Hc)))),
     L_Hp = Diagonal(repeat(Lwt, Hp)),
     Cwt = DEFAULT_CWT,
-    transcription::TranscriptionMethod = DEFAULT_LINMPC_TRANSCRIPTION,
+    transcription::ShootingMethod = DEFAULT_LINMPC_TRANSCRIPTION,
     optim::JuMP.GenericModel = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=false),
     kwargs...
 )
@@ -259,7 +259,7 @@ function LinMPC(
     N_Hc = Diagonal(repeat(Nwt, get_Hc(move_blocking(Hp, Hc)))),
     L_Hp = Diagonal(repeat(Lwt, Hp)),
     Cwt  = DEFAULT_CWT,
-    transcription::TranscriptionMethod = DEFAULT_LINMPC_TRANSCRIPTION,
+    transcription::ShootingMethod = DEFAULT_LINMPC_TRANSCRIPTION,
     optim::JM = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=false),
 ) where {NT<:Real, SE<:StateEstimator{NT}, JM<:JuMP.GenericModel}
     isa(estim.model, LinModel) || error(MSG_LINMODEL_ERR) 

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -63,6 +63,7 @@ struct LinMPC{
         # dummy vals (updated just before optimization):
         R̂y, R̂u, Tu_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
         lastu0 = zeros(NT, nu)
+        validate_transcription(model, transcription)
         PΔu = init_ZtoΔU(estim, transcription, Hp, Hc)
         Pu, Tu = init_ZtoU(estim, transcription, Hp, Hc, nb)
         E, G, J, K, V, B, ex̂, gx̂, jx̂, kx̂, vx̂, bx̂ = init_predmat(

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -167,7 +167,7 @@ arguments. This controller allocates memory at each time step for the optimizati
 julia> model = LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 4);
 
 julia> mpc = LinMPC(model, Mwt=[0, 1], Nwt=[0.5], Hp=30, Hc=1)
-LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SteadyKalmanFilter estimator and:
+LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SingleShooting transcription, SteadyKalmanFilter estimator and:
  30 prediction steps Hp
   1 control steps Hc
   1 slack variable ϵ (control constraints)
@@ -237,7 +237,7 @@ Use custom state estimator `estim` to construct `LinMPC`.
 julia> estim = KalmanFilter(LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 4), i_ym=[2]);
 
 julia> mpc = LinMPC(estim, Mwt=[0, 1], Nwt=[0.5], Hp=30, Hc=1)
-LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, KalmanFilter estimator and:
+LinMPC controller with a sample time Ts = 4.0 s, OSQP optimizer, SingleShooting transcription, KalmanFilter estimator and:
  30 prediction steps Hp
   1 control steps Hc
   1 slack variable ϵ (control constraints)

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -94,7 +94,7 @@ struct NonLinMPC{
         Eŝ, Gŝ, Jŝ, Kŝ, Vŝ, Bŝ = init_defectmat(model, estim, transcription, Hp, Hc)
         # dummy vals (updated just before optimization):
         F, fx̂, Fŝ  = zeros(NT, ny*Hp), zeros(NT, nx̂), zeros(NT, nx̂*Hp)
-        con, nϵ, P̃Δu, P̃u, Ẽ, Ẽŝ = init_defaultcon_mpc(
+        con, nϵ, P̃Δu, P̃u, Ẽ = init_defaultcon_mpc(
             estim, weights, transcription,
             Hp, Hc, 
             PΔu, Pu, E, 

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -86,6 +86,7 @@ struct NonLinMPC{
         # dummy vals (updated just before optimization):
         R̂y, R̂u, Tu_lastu0 = zeros(NT, ny*Hp), zeros(NT, nu*Hp), zeros(NT, nu*Hp)
         lastu0 = zeros(NT, nu)
+        validate_transcription(model, transcription)
         PΔu = init_ZtoΔU(estim, transcription, Hp, Hc)
         Pu, Tu = init_ZtoU(estim, transcription, Hp, Hc, nb)
         E, G, J, K, V, B, ex̂, gx̂, jx̂, kx̂, vx̂, bx̂ = init_predmat(

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -562,8 +562,10 @@ Inspired from: [User-defined operators with vector outputs](@extref JuMP User-de
 function get_optim_functions(mpc::NonLinMPC, ::JuMP.GenericModel{JNT}) where JNT<:Real
     # ----------- common cache for Jfunc, gfuncs and geqfuncs  ----------------------------
     model = mpc.estim.model
+    transcription = mpc.transcription
     grad, jac = mpc.gradient, mpc.jacobian
-    nu, ny, nx̂, nϵ, nk = model.nu, model.ny, mpc.estim.nx̂, mpc.nϵ, model.nk
+    nu, ny, nx̂, nϵ = model.nu, model.ny, mpc.estim.nx̂, mpc.nϵ
+    nk = get_nk(model, transcription)
     Hp, Hc = mpc.Hp, mpc.Hc
     ng, nc, neq = length(mpc.con.i_g), mpc.con.nc, mpc.con.neq
     nZ̃, nU, nŶ, nX̂, nK = length(mpc.Z̃), Hp*nu, Hp*ny, Hp*nx̂, Hp*nk

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -223,7 +223,7 @@ This controller allocates memory at each time step for the optimization.
 julia> model = NonLinModel((x,u,_,_)->0.5x+u, (x,_,_)->2x, 10.0, 1, 1, 1, solver=nothing);
 
 julia> mpc = NonLinMPC(model, Hp=20, Hc=1, Cwt=1e6)
-NonLinMPC controller with a sample time Ts = 10.0 s, Ipopt optimizer, UnscentedKalmanFilter estimator and:
+NonLinMPC controller with a sample time Ts = 10.0 s, Ipopt optimizer, SingleShooting transcription, UnscentedKalmanFilter estimator and:
  20 prediction steps Hp
   1 control steps Hc
   1 slack variable ϵ (control constraints)
@@ -327,7 +327,7 @@ julia> model = NonLinModel((x,u,_,_)->0.5x+u, (x,_,_)->2x, 10.0, 1, 1, 1, solver
 julia> estim = UnscentedKalmanFilter(model, σQint_ym=[0.05]);
 
 julia> mpc = NonLinMPC(estim, Hp=20, Hc=1, Cwt=1e6)
-NonLinMPC controller with a sample time Ts = 10.0 s, Ipopt optimizer, UnscentedKalmanFilter estimator and:
+NonLinMPC controller with a sample time Ts = 10.0 s, Ipopt optimizer, SingleShooting transcription, UnscentedKalmanFilter estimator and:
  20 prediction steps Hp
   1 control steps Hc
   1 slack variable ϵ (control constraints)

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -78,7 +78,9 @@ equality constraint function and by using the implicit trapezoidal rule. It can 
 moderately stiff systems and is A-stable. However, it may not be as efficient as more
 advanced collocation methods for highly stiff systems. Note that the stochastic model of the
 unmeasured disturbances is strictly discrete-time, it is thus transcribed separately using 
-[`MultipleShooting`](@ref). Also note that the state  
+[`MultipleShooting`](@ref). Also note that the built-in [`StateEstimator`](@ref) will still
+use the `solver` provided at the construction of the [`NonLinModel`](@ref) to estimate the
+plant states, not the trapezoidal rule (see `supersample` option for stiff systems). 
 
 Sparse optimizers like `Ipopt` and sparse Jacobian computations are recommended for this
 transcription method.

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -61,6 +61,42 @@ function get_nZ(estim::StateEstimator, ::MultipleShooting, Hp, Hc)
     return estim.model.nu*Hc + estim.nx̂*Hp
 end
 
+
+@doc raw"""
+    TrapezoidalMethod()
+
+An implicit trapezoidal transcription method (not yet implemented).
+
+This is presumably the simplest collocation method. It can handle moderately stiff systems
+and is A-stable. However, it may not be as efficient as more advanced methods for highly
+stiff systems. The decision variables are the same as for [`MultipleShooting`](@ref), hence
+a similar algorithm complexity.
+
+# Extended Help
+
+!!! details "Extended Help"
+    The trapezoidal method estimates the defects with:
+    by:
+    ```math
+    \mathbf{Ŝ}(k) = \mathbf{Ẽ_ŝ Z̃} + \mathbf{K_ŝ x̂_0}(k) + 0.5\frac{T_s}\big(\mathbf{F̂}(k+1) + \mathbf{F̂}(k)\big)
+    ```
+    where ``T_s`` is the sampling period, ``\mathbf{Ẽ}`` the matrix defined at 
+    [`init_defectmat`](@ref), and ``\mathbf{F̂}(k+j)`` the stacked vector of system
+
+    where ``\mathbf{f̂}(k+j) = \mathbf{f̂}\big(\mathbf{x̂}(k+j), \mathbf{u}(k+j), \mathbf{d}(k+j)\big)``.
+    This leads to the following defect constraints for ``j=0`` to ``H_p-1``:
+    ```math
+    \mathbf{ŝ}(k+j) = \mathbf{x̂}(k+j+1) - \mathbf{x̂}(k+j) - \frac{T_s}{2} \big( \mathbf{f̂}(k+j) + \mathbf{f̂}(k+j+1) \big) = 0
+    ```
+    which are added as equality constraints in the optimization problem. The initial state
+    ``\mathbf{x̂}(k)`` is given by the state estimator, and the future states
+    ``\mathbf{x̂}(k+j+1)`` are decision variables in the optimization problem. The method
+    requires evaluating the system dynamics at both the current and next time steps, which
+    can increase computational complexity compared to explicit methods like single shooting.
+"""
+struct TrapezoidalMethod <: TranscriptionMethod end
+
+
 @doc raw"""
     init_ZtoΔU(estim::StateEstimator, transcription::TranscriptionMethod, Hp, Hc) -> PΔu
 

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1335,7 +1335,7 @@ be noted that linearization of continuous-time dynamics at non-equilibrium point
 as opposed to, for discrete-time models:
 ```math
     \mathbf{x_0}(k+1) ≈ \mathbf{A x_0}(k) + \mathbf{B_u u_0}(k) + \mathbf{B_d d_0}(k) 
-                         + \mathbf{f_{op} - \mathbf{x_{op}}
+                         + \mathbf{f_{op}} - \mathbf{x_{op}}
 ```
 hence no need to add `model.fop` and subtract `model.xop` in the collocation equations.
 """

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1315,7 +1315,7 @@ function con_nonlinprogeq!(
     return geq
 end
 
-@docs raw"""
+@doc raw"""
     con_nonlinprogeq!(
         geq, X̂0, Û0, K0
         mpc::PredictiveController, model::NonLinModel, ::TrapezoidalCollocation, U0, Z̃

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -100,6 +100,16 @@ a similar algorithm complexity.
 struct TrapezoidalCollocation <: CollocationMethod end
 
 
+function validate_transcription(::LinModel, ::CollocationMethod)
+    throw(ArgumentError("Collocation methods are not supported for LinModel."))
+    return nothing
+end
+function validate_transcription(::NonLinModel{<:Real, <:EmptySolver}, ::CollocationMethod)
+    throw(ArgumentError("Collocation methods require continuous-time NonLinModel."))
+    return nothing
+end
+validate_transcription(::SimModel, ::TranscriptionMethod) = nothing
+
 @doc raw"""
     init_ZtoΔU(estim::StateEstimator, transcription::TranscriptionMethod, Hp, Hc) -> PΔu
 
@@ -206,7 +216,9 @@ function init_ZtoU(
     return Pu, Tu
 end
 
-init_PUmat( _ , ::SingleShooting, _ , _ , PuDagger) = PuDagger
+function init_PUmat(_,::SingleShooting,_,_,PuDagger::AbstractMatrix{NT}) where NT<:Real
+    return PuDagger
+end
 function init_PUmat(
     estim, ::TranscriptionMethod, Hp, _ , PuDagger::AbstractMatrix{NT}
 ) where NT<:Real

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -76,14 +76,20 @@ order hold) between the samples, but linear interpolation will be added soon.
 This transcription computes the predictions by calling the continuous-time model in the
 equality constraint function and by using the implicit trapezoidal rule. It can handle
 moderately stiff systems and is A-stable. However, it may not be as efficient as more
-advanced collocation methods for highly stiff systems. Note that the stochastic model of the
-unmeasured disturbances is strictly discrete-time, it is thus transcribed separately using 
-[`MultipleShooting`](@ref). Also note that the built-in [`StateEstimator`](@ref) will still
-use the `solver` provided at the construction of the [`NonLinModel`](@ref) to estimate the
-plant states, not the trapezoidal rule (see `supersample` option for stiff systems). 
+advanced collocation methods for highly stiff systems. Note that the built-in [`StateEstimator`](@ref)
+will still use the `solver` provided at the construction of the [`NonLinModel`](@ref) to
+estimate the plant states, not the trapezoidal rule (see `supersample` option of 
+[`RungeKutta`](@ref) for stiff systems). See Extended Help for more details.
 
 Sparse optimizers like `Ipopt` and sparse Jacobian computations are recommended for this
 transcription method.
+
+# Extended Help
+!!! details "Extended Help"
+    Note that the stochastic model of the unmeasured disturbances is strictly discrete-time,
+    as described in [`ModelPredictiveControl.init_estimstoch`](@ref). Collocation methods
+    require continuous-time dynamics. Because of this, the stochastic states are transcribed
+    separately using a [`MultipleShooting`](@ref) method.
 """
 struct TrapezoidalCollocation <: CollocationMethod
     nc::Int

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -94,7 +94,7 @@ a similar algorithm complexity.
     requires evaluating the system dynamics at both the current and next time steps, which
     can increase computational complexity compared to explicit methods like single shooting.
 """
-struct TrapezoidalMethod <: TranscriptionMethod end
+struct TrapezoidalCollocation <: TranscriptionMethod end
 
 
 @doc raw"""

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1124,8 +1124,7 @@ function predict!(
     mpc::PredictiveController, model::NonLinModel, ::SingleShooting,
     U0, _
 )
-    nu, nx̂, ny, nd, nk = model.nu, mpc.estim.nx̂, model.ny, model.nd, model.nk
-    Hp, Hc = mpc.Hp, mpc.Hc
+    nu, nx̂, ny, nd, nk, Hp = model.nu, mpc.estim.nx̂, model.ny, model.nd, model.nk, mpc.Hp
     D̂0 = mpc.D̂0
     x̂0 = @views mpc.estim.x̂0[1:nx̂]
     d0 = @views mpc.d0[1:nd]
@@ -1209,7 +1208,7 @@ custom constraints are include in the `g` vector.
 function con_nonlinprog!(
     g, mpc::PredictiveController, ::NonLinModel, ::TranscriptionMethod, x̂0end, Ŷ0, gc, ϵ
 )
-    nx̂, nŶ = length(x̂0end), length(Ŷ0)
+    nŶ = length(Ŷ0)
     for i in eachindex(g)
         mpc.con.i_g[i] || continue
         if i ≤ nŶ
@@ -1276,7 +1275,7 @@ function con_nonlinprogeq!(
     geq, X̂0, Û0, K0, 
     mpc::PredictiveController, model::NonLinModel, ::MultipleShooting, U0, Z̃
 )
-    nu, nx̂, ny, nd, nk = model.nu, mpc.estim.nx̂, model.ny, model.nd, model.nk
+    nu, nx̂, nd, nk = model.nu, mpc.estim.nx̂, model.nd, model.nk
     Hp, Hc = mpc.Hp, mpc.Hc
     nΔU, nX̂ = nu*Hc, nx̂*Hp
     D̂0 = mpc.D̂0

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -80,12 +80,12 @@ Same than [`f̂!`](@ref) for [`SimModel`](@ref) but without the `estim` argument
 """
 function f̂!(x̂0next, û0, k0, model::SimModel, As, Cs_u, x̂0, u0, d0)
     # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
-    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
-    @views x̂d_next, x̂s_next = x̂0next[1:model.nx], x̂0next[model.nx+1:end]
-    mul!(û0, Cs_u, x̂s) # ŷs_u = Cs_u * x̂s
-    û0 .+= u0
-    f!(x̂d_next, k0, model, x̂d, û0, d0, model.p)
-    mul!(x̂s_next, As, x̂s)
+    @views xd, xs = x̂0[1:model.nx], x̂0[model.nx+1:end]
+    @views xdnext, xsnext = x̂0next[1:model.nx], x̂0next[model.nx+1:end]
+    mul!(û0, Cs_u, xs)      # ys_u = Cs_u*xs
+    û0 .+= u0               # û0 = u0 + ys_u  
+    f!(xdnext, k0, model, xd, û0, d0, model.p)
+    mul!(xsnext, As, xs)
     return nothing
 end
 
@@ -116,9 +116,9 @@ Same than [`ĥ!`](@ref) for [`SimModel`](@ref) but without the `estim` argument
 """
 function ĥ!(ŷ0, model::SimModel, Cs_y, x̂0, d0)
     # `@views` macro avoid copies with matrix slice operator e.g. [a:b]
-    @views x̂d, x̂s = x̂0[1:model.nx], x̂0[model.nx+1:end]
-    h!(ŷ0, model, x̂d, d0, model.p)
-    mul!(ŷ0, Cs_y, x̂s, 1, 1) # ŷ0 = ŷ0 + Cs_y*x̂s
+    @views xd, xs = x̂0[1:model.nx], x̂0[model.nx+1:end]
+    h!(ŷ0, model, xd, d0, model.p)  # y0 = h(xd, d0)
+    mul!(ŷ0, Cs_y, xs, 1, 1)        # ŷ0 = y0 + Cs_y*xs
     return nothing
 end
 

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -33,6 +33,7 @@ function Base.show(io::IO, mpc::PredictiveController)
     n = maximum(ndigits.((Hp, Hc, nu, nx̂, nym, nyu, nd))) + 1
     println(io, "$(typeof(mpc).name.name) controller with a sample time Ts = "*
                 "$(mpc.estim.model.Ts) s, $(JuMP.solver_name(mpc.optim)) optimizer, "*
+                "$(typeof(mpc.transcription).name.name) transcription, "*
                 "$(typeof(mpc.estim).name.name) estimator and:")
     println(io, "$(lpad(Hp, n)) prediction steps Hp")
     println(io, "$(lpad(Hc, n)) control steps Hc")


### PR DESCRIPTION
I almost finished the `TapezoidalCollocation()` to handle moderately stiff system. Just need to add some tests and possibly some new benchmarks. Compared to a `MultipleShooting` transcription on the pendulum example, benchmarks are practically identical as expected, but the closed-loop response are marginally differents. This is also expected since the `MultipleShooting` uses a `RungeKutta(4)` to discretize the dynamics, while `TrapezoidalCollocation` uses a implicit trapezoidal rule.

- The `TapezoidalCollocation` only support `NonLinModel`, since `LinModel` objects currently include no information about the original continuous-time dynamics, when it's constructed from a constinuous LTI system. I'm not sure it is worth the effort refactoring `LinModel` objects to support this transcription method, although linear stiff systems do exists (i.e. large gap in the smallest and largest eigenvalues). For such corner cases, there is always the option to construct a `NonLinModel` with the continuous state-space matrices i.e.: with `f(x,u,d,_) = A*x + Bu*u + Bd*d` and `solver != nothing`.
- The built-in state estimator will still use the stepper defined in `model.solver`, which is `RungeKutta(4)` by default. For UKF or EKF, the state update function is only called a couple of times per time step, so it's not super expensive to use fixed-step solver and increase super-sampling if the system is stiff. And I don't think adding a new dependency with a root solver is worth the trouble. Neither calling `Ipopt` as a root solver. The implicit trapezoidal method is truly interesting inside an optimization problem, otherwise just use a fixed-step solver with super-sampling if necessary.
- As mentioned in the issue, the stochastic model of the unmeasured disturbances is constructed as [linear discrete-time state-space description](https://juliacontrol.github.io/ModelPredictiveControl.jl/dev/internals/state_estim/#ModelPredictiveControl.init_estimstoch). Collocation methods want continuous-time dynamics. I chose to handle the deterministic states and the stochastic states separately. The defects on the stochastic states are trivial equality constraints. In other words, the deterministic part is transcribed with `TrapezoidalCollocation` and the stochastic part is transcribed with `MultipleShooting`.
- Right now it assumes piecewise constant manipulated inputs, but I will add linear interpolation soon.

Any comment/concern on these aspects @baggepinnen ?