### PR TITLE
doc: using `MultipleShooting` in the manual for the unstable pendulum system

### DIFF
--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -396,7 +396,26 @@ savefig("plot10_NonLinMPC.svg"); nothing # hide
 
 ![plot10_NonLinMPC](plot10_NonLinMPC.svg)
 
-The closed-loop performance is still lower than the nonlinear controller, as expected, but
+Additionally, similar results are obtained by using a sparse [`MultipleShooting`](@ref)
+transcription, which is known to be more robust for unstable systems, with a solver that can
+explicilty handle sparsity like the default `OSQP`:
+
+```@example man_nonlin
+mpc_ms = LinMPC(skf; Hp, Hc, Mwt, Nwt, Cwt=Inf, transcription=MultipleShooting())
+mpc_ms = setconstraint!(mpc_ms, umin=[-1.5], umax=[+1.5])
+```
+
+Superimposing the previous disturbance rejection plot shows almost identical results:
+
+```@example man_nonlin
+res_ms = sim!(mpc_ms, N, [180.0]; plant, x_0=[π, 0], y_step=[10])
+plot!(res_ms)
+savefig("plot10b_NonLinMPC.svg"); nothing # hide
+```
+
+![plot10b_NonLinMPC](plot10b_NonLinMPC.svg)
+
+The closed-loop performances are still lower than the nonlinear controller, as expected, but
 computations are about 210 times faster (0.000071 s versus 0.015 s per time steps, on
 average). However, remember that `linmodel` is only valid for angular positions near 180°.
 For example, the 180° setpoint response from 0° is unsatisfactory since the predictions are


### PR DESCRIPTION
Added a simple test with `OSQP` + `MultipleShooting` on the linearized inverted pendulum model.

`OSQP` + `MultipleShooting` gives similar solutions to `DAQP` + `SingleShooting`. Good news! It's consistent with the optimal control theory, that is:

- `MultipleShooting` is more adapted to unstable systems, but it needs a solver that exploit sparsity like `OSQP`. 
- Active-set methods like in `DAQP` are more robust to unstable systems for optimal control problem in its dense formulation.