### PR TITLE
added: `covestim` in `MovingHorizonEstimator` now supports `SteadyKalmanFilter`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 
 [compat]
-ControlSystemsBase = "1.18.2"
+ControlSystemsBase = "1.9"
 DAQP = "0.6, 0.7.1"
 DifferentiationInterface = "0.6.45, 0.7"
 Documenter = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 
 [compat]
-ControlSystemsBase = "1.9"
+ControlSystemsBase = "1.18.2"
 DAQP = "0.6, 0.7.1"
 DifferentiationInterface = "0.6.45, 0.7"
 Documenter = "1"

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -56,12 +56,15 @@ struct KalmanCovariances{
         Q̂::Q̂C, R̂::R̂C, P̂_0, He
     ) where {NT<:Real, Q̂C<:AbstractMatrix{NT}, R̂C<:AbstractMatrix{NT}}
         if isnothing(P̂_0)
-            P̂_0 = zeros(NT, 0, 0)
+            P̂_0 = zeros(NT, 0, 0)    # does not apply to steady-state Kalman filter
+            P̂   = zeros(NT, size(Q̂)) # will hold the steady-state error covariance
+        else
+            P̂   = copy(P̂_0)
         end
         P̂_0 = Hermitian(P̂_0, :L)
+        P̂   = Hermitian(P̂, :L)
         Q̂   = Hermitian(Q̂, :L)
         R̂   = Hermitian(R̂, :L)
-        P̂   = copy(Q̂)
         # the following variables are only for the moving horizon estimator:
         invP̄, invQ̂, invR̂ = copy(P̂_0), copy(Q̂), copy(R̂)
         try

--- a/src/estimator/construct.jl
+++ b/src/estimator/construct.jl
@@ -59,9 +59,9 @@ struct KalmanCovariances{
             P̂_0 = zeros(NT, 0, 0)
         end
         P̂_0 = Hermitian(P̂_0, :L)
-        P̂   = copy(P̂_0)
         Q̂   = Hermitian(Q̂, :L)
         R̂   = Hermitian(R̂, :L)
+        P̂   = copy(Q̂)
         # the following variables are only for the moving horizon estimator:
         invP̄, invQ̂, invR̂ = copy(P̂_0), copy(Q̂), copy(R̂)
         try

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -196,11 +196,11 @@ function SteadyKalmanFilter(
 end
 
 """
-    init_skf(model, i_ym, Â, Ĉ, Q̂, R̂; direct=true) -> K̂, P̂
+    init_skf(model::LinModel, i_ym, Â, Ĉ, Q̂, R̂; direct=true) -> K̂, P̂
 
 Initialize the steady-state Kalman gain `K̂` and estimation error covariance `P̂`.
 """
-function init_skf(model, i_ym, Â, Ĉ, Q̂, R̂; direct=true)
+function init_skf(model::LinModel{NT}, i_ym, Â, Ĉ, Q̂, R̂; direct=true) where {NT<:Real}
     ny, nym = model.ny, length(i_ym)
     if ny != nym
         R̂_y = zeros(NT, ny, ny)

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -43,7 +43,7 @@ struct SteadyKalmanFilter{
         Â, B̂u, Ĉ, B̂d, D̂d, x̂op, f̂op = augment_model(model, As, Cs_u, Cs_y)
         Ĉm, D̂dm = Ĉ[i_ym, :], D̂d[i_ym, :]
         R̂, Q̂ = cov.R̂, cov.Q̂
-        K̂, P̂ = init_skf(model, i_ym, Â, Ĉ, Q̂, R̂; direct)
+        K̂, P̂ = init_skf(i_ym, Â, Ĉ, Q̂, R̂; direct)
         cov.P̂ .= P̂
         x̂0 = [zeros(NT, model.nx); zeros(NT, nxs)]
         corrected = [false]
@@ -196,7 +196,7 @@ function SteadyKalmanFilter(
 end
 
 """
-    init_skf(model::LinModel, i_ym, Â, Ĉ, Q̂, R̂; direct=true) -> K̂, P̂
+    init_skf(i_ym, Â, Ĉ, Q̂, R̂; direct=true) -> K̂, P̂
 
 Initialize the steady-state Kalman gain `K̂` and estimation error covariance `P̂`.
 """

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -219,8 +219,8 @@ function init_skf(model, i_ym, Â, Ĉ, Q̂, R̂; direct=true)
     catch my_error
         if isa(my_error, ErrorException)
             error("Cannot compute the optimal Kalman gain K̂ for the "* 
-                    "SteadyKalmanFilter. You may try to remove integrators with "*
-                    "nint_u/nint_ym parameter or use the time-varying KalmanFilter.")
+                  "SteadyKalmanFilter. You may try to remove integrators with "*
+                  "nint_u/nint_ym parameter or use the time-varying KalmanFilter.")
         else
             rethrow()
         end

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -221,12 +221,6 @@ function setmodel_estimator!(estim::SteadyKalmanFilter, model, _ , _ , _ , Q̂, 
     return nothing
 end
 
-"Throw an error if P̂ != nothing."
-function setstate_cov!(::SteadyKalmanFilter, P̂)
-    isnothing(P̂) || error("SteadyKalmanFilter does not compute an estimation covariance matrix P̂.")
-    return nothing
-end
-
 @doc raw"""
     correct_estimate!(estim::SteadyKalmanFilter, y0m, d0)
 

--- a/src/estimator/mhe.jl
+++ b/src/estimator/mhe.jl
@@ -5,6 +5,7 @@ include("mhe/execute.jl")
 function print_details(io::IO, estim::MovingHorizonEstimator)
     println(io, "├ optimizer: $(JuMP.solver_name(estim.optim)) ")
     print_backends(io, estim, estim.model)
+    println(io, "├ arrival covariance: $(nameof(typeof(estim.covestim))) ")
 end
 
 "Print the differentiation backends for `SimModel`."

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -280,6 +280,7 @@ MovingHorizonEstimator estimator with a sample time Ts = 10.0 s:
 ├ optimizer: Ipopt
 ├ gradient: AutoForwardDiff
 ├ jacobian: AutoForwardDiff
+├ arrival covariance: UnscentedKalmanFilter
 └ dimensions:
   ├ 5 estimation steps He
   ├ 0 slack variable ε (estimation constraints)
@@ -514,6 +515,7 @@ julia> estim = setconstraint!(estim, x̂min=[-50, -50], x̂max=[50, 50])
 MovingHorizonEstimator estimator with a sample time Ts = 1.0 s:
 ├ model: LinModel
 ├ optimizer: OSQP
+├ arrival covariance: KalmanFilter
 └ dimensions:
   ├ 3 estimation steps He
   ├ 0 slack variable ε (estimation constraints)

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -423,8 +423,10 @@ This syntax allows nonzero off-diagonal elements in ``\mathbf{P̂_i}, \mathbf{Q�
 where ``\mathbf{P̂_i}`` is the initial estimation covariance, provided by `P̂_0` argument. The
 keyword argument `covestim` also allows specifying a custom [`StateEstimator`](@ref) object
 for the estimation of covariance at the arrival ``\mathbf{P̂}_{k-N_k}(k-N_k+p)``. The
-supported types are [`KalmanFilter`](@ref), [`UnscentedKalmanFilter`](@ref) and 
-[`ExtendedKalmanFilter`](@ref).
+supported types are [`SteadyKalmanFilter`](@ref), [`KalmanFilter`](@ref), 
+[`UnscentedKalmanFilter`](@ref) and [`ExtendedKalmanFilter`](@ref). A constant arrival
+covariance is supported with [`SteadyKalmanFilter`](@ref), and by setting the `P̂` argument 
+of [`setstate!`](@ref) at the desired value.
 """
 function MovingHorizonEstimator(
     model::SM, He, i_ym, nint_u, nint_ym, P̂_0, Q̂, R̂, Cwt=Inf;

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -904,6 +904,14 @@ end
     @test_throws ArgumentError MovingHorizonEstimator(linmodel)
     @test_throws ArgumentError MovingHorizonEstimator(linmodel, He=0)
     @test_throws ArgumentError MovingHorizonEstimator(linmodel, Cwt=-1)
+    @test_throws ErrorException MovingHorizonEstimator(
+        nonlinmodel, 5, 1:2, 0, [1, 1], I_6, I_6, I_2, Inf; optim, 
+        covestim = InternalModel(nonlinmodel)
+    )
+    @test_throws ArgumentError MovingHorizonEstimator(
+        nonlinmodel, 5, 1:2, 0, [1, 1], I_6, I_6, I_2, Inf; optim, 
+        covestim = UnscentedKalmanFilter(nonlinmodel, nint_ym=[2,2])
+    )
 end
 
 @testitem "MovingHorizonEstimator estimation and getinfo" setup=[SetupMPCtests] begin

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -112,7 +112,6 @@ end
     @test x̂ ≈ [0, 0]
     @test isa(x̂, Vector{Float32})
     @test_throws ArgumentError updatestate!(kalmanfilter1, [10, 50])
-    @test_throws ErrorException setstate!(kalmanfilter1, [1,2,3,4], diagm(.1:.1:.4))
 end 
 
 @testitem "SteadyKalmanFilter set model" setup=[SetupMPCtests] begin


### PR DESCRIPTION
This new feature allows two things: 

1) fixing the arrival covariance of the MHE at the Kalman Filter steady-state value $\mathbf{\hat{P}}(\infty)$. This is common choice in the literature, and its the default behaviour when `covestim` is a `SteadyKalmanFilter`. Note that the default `covestim` for the MHE with a `LinModel` is still a time-varying `KalmanFilter`.
2) with some tweaking, fixing the arrival covariance at an arbitrary value selected by the user, for example:
    ```julia
    using ControlSystemsBase, ModelPredictiveControl, LinearAlgebra
    linmodel = LinModel(tf(2, [10, 1]), 1.0)
    i_ym, nint_u, nint_ym, He = 1:1, [1], 0, 10
    Q̂ = diagm([1/2, 1].^2) 
    R̂ = diagm([1].^2)
    covestim = SteadyKalmanFilter(linmodel, i_ym, nint_u, nint_ym, Q̂, R̂)
    P̂_0 = diagm([0.1, 0.1].^2) # user-specified fixed arrival covariance
    setstate!(covestim, zeros(2), P̂_0)
    mhe = MovingHorizonEstimator(linmodel, He, i_ym, nint_u, nint_ym, P̂_0, Q̂, R̂; covestim)
    for i in 1:25
        y = [2.0]
        x̂ = preparestate!(mhe, y)
        u = [0.0]
        println(x̂)
        updatestate!(mhe, u, y)
    end
    ```
    The same is also possible with `NonLinModel`. The user just needs to construct a `SteadyKalmanFilter` with a dummy `LinModel` with the same number of estimated state `nx̂` than the MHE, and fix the arrival covariance using `setstate!` as above. 

The `covestim` argument is also now displayed when pretty-printing a `MovingHorizonEstimator`, in the "arrival covariance" field:

```
MovingHorizonEstimator estimator with a sample time Ts = 4.0 s:
├ model: LinModel
├ optimizer: OSQP 
├ arrival covariance: SteadyKalmanFilter 
└ dimensions:
  ├ 5 estimation steps He
  ├ 0 slack variable ε (estimation constraints)
  ├ 2 manipulated inputs u (0 integrating states)
  ├ 4 estimated states x̂
  ├ 2 measured outputs ym (0 integrating states)
  ├ 0 unmeasured outputs yu
  └ 1 measured disturbances d
```


~~Note that it relies on the new `extra=Val(true)` arguments in `ControlSystemsBase.jl`, introduced in v1.18.2. This PR hence bumps the compat entry to `ControlSystemsBase = "1.18.2"`~~
edit: Come to think of it, I don't this that's a good idea to bump the compat of `ControlSystemsBase.jl` just for this niche feature. I now rely on `pkgversion(ControlSystemsBase)` to pass or not the `extra` keyword argument to `kalman`. Do you see any drawback to this workaround @baggepinnen ?

edit 2: Also I notice that the computed steady-state Kalman gain with `direct=true` is not the same before and after v1.18.2, you corrected a mistake in the formula @baggepinnen ?