### PR TITLE
changed: fill inequality vector `g` even if `-Inf` bounds

### DIFF
--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1030,7 +1030,6 @@ function con_nonlinprog!(
 )
     nŶ = length(Ŷ0)
     for i in eachindex(g)
-        mpc.con.i_g[i] || continue
         if i ≤ nŶ
             j = i
             g[i] = (mpc.con.Y0min[j] - Ŷ0[j])     - ϵ*mpc.con.C_ymin[j]
@@ -1060,7 +1059,6 @@ function con_nonlinprog!(
 )
     nx̂, nŶ = length(x̂0end), length(Ŷ0)
     for i in eachindex(g)
-        mpc.con.i_g[i] || continue
         if i ≤ nŶ
             j = i
             g[i] = (mpc.con.Y0min[j] - Ŷ0[j])     - ϵ*mpc.con.C_ymin[j]

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -703,7 +703,6 @@ function con_nonlinprog_mhe!(g, estim::MovingHorizonEstimator, ::SimModel, X̂0,
     nX̂con, nX̂ = length(estim.con.X̂0min), estim.nx̂ *estim.Nk[]
     nV̂con, nV̂ = length(estim.con.V̂min),  estim.nym*estim.Nk[]
     for i in eachindex(g)
-        estim.con.i_g[i] || continue
         if i ≤ nX̂con
             j = i
             jcon = nX̂con-nX̂+j


### PR DESCRIPTION
It probably does not save much computation and this is a source of future bug (since i'm filling `g` in-place). I shot myself in the foot multiple time because of this small "performance optimization".
Let's benchmark this change in a separate PR.