### PR TITLE
test: improve robustness of time-constrained tests

### DIFF
--- a/src/estimator/manual.jl
+++ b/src/estimator/manual.jl
@@ -100,7 +100,7 @@ ManualEstimator estimator with a sample time Ts = 0.5 s:
     julia> function man_sim()
                f(x,u,_,_) = 0.5*sin.(x + u)
                h(x,_,_) = x
-               model = NonLinModel(f, h, 10.0, 1, 1, 1, solver=nothing)
+               model = NonLinModel(f, h, 100.0, 1, 1, 1, solver=nothing)
                linModel = linearize(model, x=[0], u=[0])
                man = ManualEstimator(linModel, nint_u=[1])
                mpc = LinMPC(man)

--- a/test/1_test_sim_model.jl
+++ b/test/1_test_sim_model.jl
@@ -144,7 +144,7 @@ end
         updatestate!(linmodel1, [1])
         periodsleep(linmodel1)
     end
-    @test all(isapprox.(diff(times1[2:end]), 0.25, atol=0.01))
+    @test all(isapprox.(diff(times1[2:end]), 0.25, atol=0.025))
     linmodel2 = LinModel(tf(2, [0.1, 1]), 0.25)
     times2 = zeros(5)
     for i=1:5
@@ -390,7 +390,7 @@ end
 
 @testitem "NonLinModel real time simulations" setup=[SetupMPCtests] begin
     using .SetupMPCtests, ControlSystemsBase, LinearAlgebra
-    linmodel1 = LinModel(tf(2, [10, 1]), 0.1)
+    linmodel1 = LinModel(tf(2, [10, 1]), 0.25)
     nonlinmodel1 = NonLinModel(
         (x,u,_,_)->linmodel1.A*x + linmodel1.Bu*u,
         (x,_,_)->linmodel1.C*x,
@@ -402,8 +402,8 @@ end
         updatestate!(nonlinmodel1, [1])
         periodsleep(nonlinmodel1)
     end
-    @test all(isapprox.(diff(times1[2:end]), 0.1, atol=0.01))
-    linmodel2 = LinModel(tf(2, [0.1, 1]), 0.001)
+    @test all(isapprox.(diff(times1[2:end]), 0.25, atol=0.025))
+    linmodel2 = LinModel(tf(2, [0.1, 1]), 0.25)
     nonlinmodel2 = NonLinModel(
         (x,u,_,_)->linmodel2.A*x + linmodel2.Bu*u,
         (x,_,_)->linmodel2.C*x,
@@ -415,5 +415,5 @@ end
         updatestate!(nonlinmodel2, [1])
         periodsleep(nonlinmodel2, true)
     end
-    @test all(isapprox.(diff(times2[2:end]), 0.001, atol=0.0001))
+    @test all(isapprox.(diff(times2[2:end]), 0.25, atol=0.0001))
 end


### PR DESCRIPTION
These test was failing systematically on Windows 11. I increased the sampling time to allow slower execution without failing.