### PR TITLE
debug: adequate padding for MHE dimensions printing

### DIFF
--- a/src/estimator/mhe.jl
+++ b/src/estimator/mhe.jl
@@ -1,6 +1,9 @@
 include("mhe/construct.jl")
 include("mhe/execute.jl")
 
+"Return estimation horizon He and slack variables length nε for `MovingHorizonEstimator`."
+get_other_dims(estim::MovingHorizonEstimator) = (estim.He, estim.nε)
+
 "Print optimizer and other information for `MovingHorizonEstimator`."
 function print_details(io::IO, estim::MovingHorizonEstimator)
     println(io, "├ optimizer: $(JuMP.solver_name(estim.optim)) ")

--- a/src/predictive_control.jl
+++ b/src/predictive_control.jl
@@ -31,7 +31,8 @@ function Base.show(io::IO, mpc::PredictiveController)
     Hp, Hc, nϵ = mpc.Hp, mpc.Hc, mpc.nϵ
     nu, nd = model.nu, model.nd
     nx̂, nym, nyu = estim.nx̂, estim.nym, estim.nyu
-    n = maximum(ndigits.((Hp, Hc, nu, nx̂, nym, nyu, nd))) + 1
+    other_dims = get_other_dims(estim)
+    n = maximum(ndigits.((Hp, Hc, nu, nx̂, nym, nyu, nd, other_dims...))) + 1
     println(io, "$(nameof(typeof(mpc))) controller with a sample time Ts = $(model.Ts) s:")
     println(io, "├ estimator: $(nameof(typeof(mpc.estim)))")
     println(io, "├ model: $(nameof(typeof(model)))")

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -32,13 +32,17 @@ function Base.show(io::IO, estim::StateEstimator)
     model = estim.model
     nu, nd = model.nu, model.nd
     nx̂, nym, nyu = estim.nx̂, estim.nym, estim.nyu
-    n = maximum(ndigits.((nu, nx̂, nym, nyu, nd))) + 1
+    other_dims = get_other_dims(estim)
+    n = maximum(ndigits.((nu, nx̂, nym, nyu, nd, other_dims...))) + 1
     println(io, "$(nameof(typeof(estim))) estimator with a sample time Ts = $(model.Ts) s:")
     println(io, "├ model: $(nameof(typeof(estim.model)))")
     print_details(io, estim)
     println(io, "└ dimensions:")
     print_estim_dim(io, estim, n)
 end
+
+"Return additional dimensions on `estim` if any, for adequate padding with spaces."
+get_other_dims(::StateEstimator) = tuple()
 
 "Print additional details of `estim` if any (no details by default)."
 print_details(::IO, ::StateEstimator) = nothing


### PR DESCRIPTION
Before:

```
MovingHorizonEstimator estimator with a sample time Ts = 4.0 s:
├ model: LinModel
├ optimizer: Ipopt 
├ arrival covariance: KalmanFilter 
└ dimensions:
  ├10 estimation steps He
  ├ 0 slack variable ε (estimation constraints)
  ├ 2 manipulated inputs u (0 integrating states)
  ├ 6 estimated states x̂
  ├ 2 measured outputs ym (2 integrating states)
  ├ 0 unmeasured outputs yu
  └ 1 measured disturbances d
```

After:

```
MovingHorizonEstimator estimator with a sample time Ts = 4.0 s:
├ model: LinModel
├ optimizer: Ipopt 
├ arrival covariance: KalmanFilter 
└ dimensions:
  ├ 10 estimation steps He
  ├  0 slack variable ε (estimation constraints)
  ├  2 manipulated inputs u (0 integrating states)
  ├  6 estimated states x̂
  ├  2 measured outputs ym (2 integrating states)
  ├  0 unmeasured outputs yu
  └  1 measured disturbances d
```
