### PR TITLE
added: pretty-print `estim.direct` for all `StateEstimator`s

### DIFF
--- a/src/estimator/internal_model.jl
+++ b/src/estimator/internal_model.jl
@@ -82,6 +82,7 @@ estimator is allocation-free if `model` simulations do not allocate.
 julia> estim = InternalModel(LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 0.5), i_ym=[2])
 InternalModel estimator with a sample time Ts = 0.5 s:
 ├ model: LinModel
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u
   ├ 2 estimated states x̂

--- a/src/estimator/kalman.jl
+++ b/src/estimator/kalman.jl
@@ -119,6 +119,7 @@ julia> model = LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 0.5);
 julia> estim = SteadyKalmanFilter(model, i_ym=[2], σR=[1], σQint_ym=[0.01])
 SteadyKalmanFilter estimator with a sample time Ts = 0.5 s:
 ├ model: LinModel
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u (0 integrating states)
   ├ 3 estimated states x̂
@@ -410,6 +411,7 @@ julia> model = LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 0.5);
 julia> estim = KalmanFilter(model, i_ym=[2], σR=[1], σP_0=[100, 100], σQint_ym=[0.01])
 KalmanFilter estimator with a sample time Ts = 0.5 s:
 ├ model: LinModel
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u (0 integrating states)
   ├ 3 estimated states x̂
@@ -656,6 +658,7 @@ julia> model = NonLinModel((x,u,_,_)->0.1x+u, (x,_,_)->2x, 10.0, 1, 1, 1, solver
 julia> estim = UnscentedKalmanFilter(model, σR=[1], nint_ym=[2], σPint_ym_0=[1, 1])
 UnscentedKalmanFilter estimator with a sample time Ts = 10.0 s:
 ├ model: NonLinModel
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u (0 integrating states)
   ├ 3 estimated states x̂
@@ -1023,6 +1026,7 @@ julia> estim = ExtendedKalmanFilter(model, σQ=[2], σQint_ym=[2], σP_0=[0.1], 
 ExtendedKalmanFilter estimator with a sample time Ts = 5.0 s:
 ├ model: NonLinModel
 ├ jacobian: AutoForwardDiff
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u (0 integrating states)
   ├ 2 estimated states x̂
@@ -1190,8 +1194,10 @@ function update_estimate!(estim::ExtendedKalmanFilter{NT}, y0m, d0, u0) where NT
     return predict_estimate_kf!(estim, u0, d0, F̂)
 end
 
+"Print the `jacobian` backend and `direct` flag for [`ExtendedKalmanFilter`](@ref)."
 function print_details(io::IO, estim::ExtendedKalmanFilter)
     println(io, "├ jacobian: $(backend_str(estim.jacobian))")
+    println(io, "├ direct: $(estim.direct)")
 end
 
 "Set `estim.cov.P̂` to `estim.cov.P̂_0` for the time-varying Kalman Filters."

--- a/src/estimator/luenberger.jl
+++ b/src/estimator/luenberger.jl
@@ -85,6 +85,7 @@ julia> model = LinModel([tf(3, [30, 1]); tf(-2, [5, 1])], 0.5);
 julia> estim = Luenberger(model, nint_ym=[1, 1], poles=[0.61, 0.62, 0.63, 0.64])
 Luenberger estimator with a sample time Ts = 0.5 s:
 ├ model: LinModel
+├ direct: true
 └ dimensions:
   ├ 1 manipulated inputs u (0 integrating states)
   ├ 4 estimated states x̂

--- a/src/estimator/manual.jl
+++ b/src/estimator/manual.jl
@@ -156,3 +156,6 @@ function setstate_cov!(::ManualEstimator, P̂)
     isnothing(P̂) || error("ManualEstimator does not compute an estimation covariance matrix P̂.")
     return nothing
 end
+
+"No details for `ManualEstimator`."
+print_details(::IO, ::ManualEstimator) = nothing

--- a/src/estimator/mhe.jl
+++ b/src/estimator/mhe.jl
@@ -11,7 +11,7 @@ function print_details(io::IO, estim::MovingHorizonEstimator)
     println(io, "├ arrival covariance: $(nameof(typeof(estim.covestim))) ")
 end
 
-"Print the differentiation backends for `SimModel`."
+"Print the differentiation backends of `MovingHorizonEstimator` for `SimModel`."
 function print_backends(io::IO, estim::MovingHorizonEstimator, ::SimModel)
     println(io, "├ gradient: $(backend_str(estim.gradient))")
     println(io, "├ jacobian: $(backend_str(estim.jacobian))")

--- a/src/estimator/mhe.jl
+++ b/src/estimator/mhe.jl
@@ -9,6 +9,7 @@ function print_details(io::IO, estim::MovingHorizonEstimator)
     println(io, "├ optimizer: $(JuMP.solver_name(estim.optim)) ")
     print_backends(io, estim, estim.model)
     println(io, "├ arrival covariance: $(nameof(typeof(estim.covestim))) ")
+    println(io, "├ direct: $(estim.direct)")
 end
 
 "Print the differentiation backends of `MovingHorizonEstimator` for `SimModel`."

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -328,6 +328,7 @@ MovingHorizonEstimator estimator with a sample time Ts = 10.0 s:
 ├ jacobian: AutoForwardDiff
 ├ hessian: nothing
 ├ arrival covariance: UnscentedKalmanFilter 
+├ direct: true
 └ dimensions:
   ├ 5 estimation steps He
   ├ 0 slack variable ε (estimation constraints)
@@ -752,6 +753,7 @@ MovingHorizonEstimator estimator with a sample time Ts = 1.0 s:
 ├ model: LinModel
 ├ optimizer: OSQP
 ├ arrival covariance: KalmanFilter
+├ direct: true
 └ dimensions:
   ├ 3 estimation steps He
   ├ 0 slack variable ε (estimation constraints)

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -37,7 +37,7 @@ function Base.show(io::IO, estim::StateEstimator)
     println(io, "$(nameof(typeof(estim))) estimator with a sample time Ts = $(model.Ts) s:")
     println(io, "├ model: $(nameof(typeof(estim.model)))")
     print_details(io, estim)
-    println(io, "├ direct: $(estim.direct) ")
+    println(io, "├ direct: $(estim.direct)")
     println(io, "└ dimensions:")
     print_estim_dim(io, estim, n)
 end

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -37,7 +37,6 @@ function Base.show(io::IO, estim::StateEstimator)
     println(io, "$(nameof(typeof(estim))) estimator with a sample time Ts = $(model.Ts) s:")
     println(io, "├ model: $(nameof(typeof(estim.model)))")
     print_details(io, estim)
-    println(io, "├ direct: $(estim.direct)")
     println(io, "└ dimensions:")
     print_estim_dim(io, estim, n)
 end
@@ -45,8 +44,10 @@ end
 "Return additional dimensions on `estim` if any, for adequate padding with spaces."
 get_other_dims(::StateEstimator) = tuple()
 
-"Print additional details of `estim` if any (no details by default)."
-print_details(::IO, ::StateEstimator) = nothing
+"Print only the `estim.direct` field by default."
+function print_details(io::IO, estim::StateEstimator)
+    println(io, "├ direct: $(estim.direct)")
+end
 
 "Print the overall dimensions of the state estimator `estim` with left padding `n`."
 function print_estim_dim(io::IO, estim::StateEstimator, n)

--- a/src/state_estim.jl
+++ b/src/state_estim.jl
@@ -37,6 +37,7 @@ function Base.show(io::IO, estim::StateEstimator)
     println(io, "$(nameof(typeof(estim))) estimator with a sample time Ts = $(model.Ts) s:")
     println(io, "├ model: $(nameof(typeof(estim.model)))")
     print_details(io, estim)
+    println(io, "├ direct: $(estim.direct) ")
     println(io, "└ dimensions:")
     print_estim_dim(io, estim, n)
 end


### PR DESCRIPTION
It is more explicit for the user since the default is `direct=true`, and the behavior between `true` and `false` is drastically different for the MHE (`preparestate!` do the optimization for the former, and `updatestate!`, for the latter). 

It looks like this:
```
MovingHorizonEstimator estimator with a sample time Ts = 4.0 s:
├ model: NonLinModel
├ optimizer: Ipopt 
├ gradient: AutoForwardDiff
├ jacobian: AutoForwardDiff
├ hessian: AutoSparse (AutoForwardDiff, TracerSparsityDetector, GreedyColoringAlgorithm)
├ arrival covariance: UnscentedKalmanFilter 
├ direct: true         # <---------------------------------------------------------- NEW ITEM 
└ dimensions:
  ├ 10 estimation steps He
  ├  0 slack variable ε (estimation constraints)
  ├  2 manipulated inputs u (0 integrating states)
  ├  6 estimated states x̂
  ├  2 measured outputs ym (2 integrating states)
  ├  0 unmeasured outputs yu
  └  1 measured disturbances d
```