### PR TITLE
added: support box constraint in `LinMPC` and `NonLinMPC`

### DIFF
--- a/ext/LinearMPCext.jl
+++ b/ext/LinearMPCext.jl
@@ -56,7 +56,7 @@ function Base.convert(::Type{LinearMPC.MPC}, mpc::ModelPredictiveControl.LinMPC)
         # LinearMPC relies on a different softening mechanism (new implicit slacks for each
         # softened bounds), so we apply an approximate conversion factor on the Cwt weight:
         Cwt = weights.Ñ_Hc[end, end]
-        nsoft = sum((mpc.con.A[:,end] .< 0) .& (mpc.con.i_b)) - 1
+        nsoft = sum((mpc.con.A[:,end] .< 0) .& (mpc.con.i_b))
         newmpc.settings.soft_weight = 10*sqrt(nsoft*Cwt)
     else
         C_u  = zeros(nu*Hp)

--- a/ext/LinearMPCext.jl
+++ b/ext/LinearMPCext.jl
@@ -42,7 +42,7 @@ function Base.convert(::Type{LinearMPC.MPC}, mpc::ModelPredictiveControl.LinMPC)
     if !only_hard
         issoft(C) = any(x -> x > 0, C)
         C_u  = -mpc.con.A_Umin[:, end]
-        C_Δu = -mpc.con.A_ΔŨmin[1:nΔU, end]
+        C_Δu = -mpc.con.A_ΔUmin[:, end]
         C_y  = -mpc.con.A_Ymin[:, end]
         C_w  = -mpc.con.A_Wmin[:, end]
         c_x̂  = -mpc.con.A_x̂min[:, end]
@@ -81,7 +81,7 @@ function Base.convert(::Type{LinearMPC.MPC}, mpc::ModelPredictiveControl.LinMPC)
         end
     end
     # --- Input increment constraints ---
-    ΔUmin, ΔUmax = mpc.con.ΔŨmin[1:nΔU], mpc.con.ΔŨmax[1:nΔU]
+    ΔUmin, ΔUmax = mpc.con.ΔUmin, mpc.con.ΔUmax
     I_Δu = Matrix{Float64}(I, nu, nu)
     for k = 0:Hc-1
         Δumin_k, Δumax_k = ΔUmin[k*nu+1:(k+1)*nu], ΔUmax[k*nu+1:(k+1)*nu]
@@ -198,7 +198,7 @@ function validate_constraints(mpc::ModelPredictiveControl.LinMPC)
     nΔU = mpc.Hc * mpc.estim.model.nu
     mpc.weights.isinf_C && return nothing # only hard constraints are entirely supported
     C_umin, C_umax   = -mpc.con.A_Umin[:, end], -mpc.con.A_Umax[:, end]
-    C_Δumin, C_Δumax = -mpc.con.A_ΔŨmin[1:nΔU, end], -mpc.con.A_ΔŨmax[1:nΔU, end]
+    C_Δumin, C_Δumax = -mpc.con.A_ΔUmin[:, end], -mpc.con.A_ΔUmax[:, end]
     C_ymin, C_ymax   = -mpc.con.A_Ymin[:, end], -mpc.con.A_Ymax[:, end]
     C_wmin, C_wmax   = -mpc.con.A_Wmin[:, end], -mpc.con.A_Wmax[:, end]
     C_x̂min, C_x̂max   = -mpc.con.A_x̂min[:, end], -mpc.con.A_x̂max[:, end]

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -513,6 +513,7 @@ function setconstraint!(
         con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
         con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
     )
+    Z̃var::Vector{JuMP.VariableRef} = optim[:Z̃var]
     if notSolvedYet
         con.i_b[:], con.i_g[:], con.A[:] = init_matconstraint_mpc(
             model, transcription, Z̃min, Z̃max, nc, nϵ,
@@ -527,7 +528,6 @@ function setconstraint!(
         con.Z̃min[:], con.Z̃max[:] = Z̃min, Z̃max
         A = con.A[con.i_b, :]
         b = con.b[con.i_b]
-        Z̃var::Vector{JuMP.VariableRef} = optim[:Z̃var]
         JuMP.delete(optim, optim[:linconstraint])
         JuMP.unregister(optim, :linconstraint)
         @constraint(optim, linconstraint, A*Z̃var .≤ b)

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -263,7 +263,7 @@ LinMPC controller with a sample time Ts = 4.0 s:
   │ └  0 measured disturbances d
   └ optimization:
     ├  3 decision variables Z̃ (1 slack variable)
-    ├ 25 linear inequality constraints A (0 custom)
+    ├ 20 linear inequality constraints A (0 custom)
     └  0 linear equality constraints Aeq
 ```
 

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -536,6 +536,12 @@ function setconstraint!(
         JuMP.delete(optim, optim[:linconstraint])
         JuMP.unregister(optim, :linconstraint)
         @constraint(optim, linconstraint, A*Z̃var .≤ b)
+        for i in eachindex(Z̃var)
+            JuMP.has_lower_bound(Z̃var[i]) && JuMP.delete_lower_bound(Z̃var[i])
+            JuMP.has_upper_bound(Z̃var[i]) && JuMP.delete_upper_bound(Z̃var[i])
+            !isinf(con.Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], con.Z̃min[i])
+            !isinf(con.Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], con.Z̃max[i])
+        end
         reset_nonlincon!(mpc)
     else
         i_b, i_g = init_matconstraint_mpc(

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -151,19 +151,22 @@ struct ControllerConstraint{NT<:Real, GCfunc<:Union{Nothing, Function}}
     # bounds over the prediction horizon (deviation vectors from operating points): 
     U0min   ::Vector{NT}
     U0max   ::Vector{NT}
-    ΔŨmin   ::Vector{NT}
-    ΔŨmax   ::Vector{NT}
+    ΔUmin   ::Vector{NT}
+    ΔUmax   ::Vector{NT}
     Y0min   ::Vector{NT}
     Y0max   ::Vector{NT}
     Wmin    ::Vector{NT}
     Wmax    ::Vector{NT}
     x̂0min   ::Vector{NT}
     x̂0max   ::Vector{NT}
+    # vectors for the box constraints:
+    Z̃min    ::Vector{NT}
+    Z̃max    ::Vector{NT}
     # A matrices for the linear inequality constraints:
     A_Umin  ::SparseMatrixCSC{NT, Int}
     A_Umax  ::SparseMatrixCSC{NT, Int}
-    A_ΔŨmin ::SparseMatrixCSC{NT, Int}
-    A_ΔŨmax ::SparseMatrixCSC{NT, Int}
+    A_ΔUmin ::SparseMatrixCSC{NT, Int}
+    A_ΔUmax ::SparseMatrixCSC{NT, Int}
     A_Ymin  ::Matrix{NT}
     A_Ymax  ::Matrix{NT}
     A_Wmin  ::Matrix{NT}
@@ -181,7 +184,7 @@ struct ControllerConstraint{NT<:Real, GCfunc<:Union{Nothing, Function}}
     beq     ::Vector{NT}
     # nonlinear equality constraints:
     neq     ::Int
-    # constraint softness parameter vectors needing seperate storage:
+    # constraint softness parameter vectors needing separate storage:
     C_ymin  ::Vector{NT}
     C_ymax  ::Vector{NT}
     C_wmin  ::Vector{NT}
@@ -371,20 +374,20 @@ function setconstraint!(
     if isnothing(ΔUmin) && !isnothing(Δumin)
         size(Δumin) == (nu,) || throw(DimensionMismatch("Δumin size must be $((nu,))"))
         for i = 1:nu*Hc
-            con.ΔŨmin[i] = Δumin[(i-1) % nu + 1]
+            con.ΔUmin[i] = Δumin[(i-1) % nu + 1]
         end
     elseif !isnothing(ΔUmin)
         size(ΔUmin)  == (nu*Hc,) || throw(DimensionMismatch("ΔUmin size must be $((nu*Hc,))"))
-        con.ΔŨmin[1:nu*Hc] .= ΔUmin
+        con.ΔUmin .= ΔUmin
     end
     if isnothing(ΔUmax) && !isnothing(Δumax)
         size(Δumax) == (nu,) || throw(DimensionMismatch("Δumax size must be $((nu,))"))
         for i = 1:nu*Hc
-            con.ΔŨmax[i] = Δumax[(i-1) % nu + 1]
+            con.ΔUmax[i] = Δumax[(i-1) % nu + 1]
         end
     elseif !isnothing(ΔUmax)
         size(ΔUmax)  == (nu*Hc,) || throw(DimensionMismatch("ΔUmax size must be $((nu*Hc,))"))
-        con.ΔŨmax[1:nu*Hc] .= ΔUmax
+        con.ΔUmax .= ΔUmax
     end
     if isnothing(Ymin) && !isnothing(ymin)
         size(ymin) == (ny,) || throw(DimensionMismatch("ymin size must be $((ny,))"))
@@ -404,7 +407,6 @@ function setconstraint!(
         size(Ymax) == (ny*Hp,) || throw(DimensionMismatch("Ymax size must be $((ny*Hp,))"))
         con.Y0max .= Ymax .- mpc.Yop
     end
-
     if isnothing(Wmin) && !isnothing(wmin)
         size(wmin) == (nw,) || throw(DimensionMismatch("wmin size must be $((nw,))"))
         for i = 1:nw*(Hp+1)
@@ -462,12 +464,12 @@ function setconstraint!(
         if !isnothing(C_Δumin)
             size(C_Δumin) == (nu*Hc,) || throw(DimensionMismatch("C_Δumin size must be $((nu*Hc,))"))
             any(<(0), C_Δumin) && error("C_Δumin weights should be non-negative")
-            con.A_ΔŨmin[1:end-1, end] .= -C_Δumin 
+            con.A_ΔUmin[:, end] .= -C_Δumin 
         end
         if !isnothing(C_Δumax)
             size(C_Δumax) == (nu*Hc,) || throw(DimensionMismatch("C_Δumax size must be $((nu*Hc,))"))
             any(<(0), C_Δumax) && error("C_Δumax weights should be non-negative")
-            con.A_ΔŨmax[1:end-1, end] .= -C_Δumax
+            con.A_ΔUmax[:, end] .= -C_Δumax
         end
         if !isnothing(C_ymin)
             size(C_ymin) == (ny*Hp,) || throw(DimensionMismatch("C_ymin size must be $((ny*Hp,))"))
@@ -507,17 +509,22 @@ function setconstraint!(
         end
     end
     i_Umin,  i_Umax  = .!isinf.(con.U0min), .!isinf.(con.U0max)
-    i_ΔŨmin, i_ΔŨmax = .!isinf.(con.ΔŨmin), .!isinf.(con.ΔŨmax)
+    i_ΔUmin, i_ΔUmax = .!isinf.(con.ΔUmin), .!isinf.(con.ΔUmax)
     i_Ymin,  i_Ymax  = .!isinf.(con.Y0min), .!isinf.(con.Y0max)
     i_Wmin,  i_Wmax  = .!isinf.(con.Wmin),  .!isinf.(con.Wmax)
     i_x̂min,  i_x̂max  = .!isinf.(con.x̂0min), .!isinf.(con.x̂0max)
+    box_constraints_mpc!(
+        con.Z̃min, con.Z̃max, transcription, nϵ,
+        con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
+        con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
+    )
     if notSolvedYet
         con.i_b[:], con.i_g[:], con.A[:] = init_matconstraint_mpc(
             model, transcription, nc,
-            i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, 
+            i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
             i_Ymin, i_Ymax, i_Wmin, i_Wmax,
             i_x̂min, i_x̂max,
-            con.A_Umin, con.A_Umax, con.A_ΔŨmin, con.A_ΔŨmax, 
+            con.A_Umin, con.A_Umax, con.A_ΔUmin, con.A_ΔUmax, 
             con.A_Ymin, con.A_Ymax, con.A_Wmin, con.A_Wmax,
             con.A_x̂min, con.A_x̂max,
             con.Aeq
@@ -532,7 +539,7 @@ function setconstraint!(
     else
         i_b, i_g = init_matconstraint_mpc(
             model, transcription, nc,
-            i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, 
+            i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
             i_Ymin, i_Ymax, i_Wmin, i_Wmax,
             i_x̂min, i_x̂max,
         )
@@ -886,11 +893,13 @@ function init_defaultcon_mpc(
     nW = nw*(Hp+1)
     nS = size(ES, 1)
     nϵ = weights.isinf_C ? 0 : 1
+    nZ̃ = get_nZ(estim, transcription, Hp, Hc) + nϵ
     u0min,      u0max   = fill(convert(NT,-Inf), nu), fill(convert(NT,+Inf), nu)
     Δumin,      Δumax   = fill(convert(NT,-Inf), nu), fill(convert(NT,+Inf), nu)
     y0min,      y0max   = fill(convert(NT,-Inf), ny), fill(convert(NT,+Inf), ny)
     wmin,       wmax    = fill(convert(NT,-Inf), nw), fill(convert(NT,+Inf), nw)
     x̂0min,      x̂0max   = fill(convert(NT,-Inf), nx̂), fill(convert(NT,+Inf), nx̂)
+    Z̃min,       Z̃max    = fill(convert(NT,-Inf), nZ̃), fill(convert(NT,+Inf), nZ̃)
     c_umin,     c_umax  = fill(zero(NT), nu), fill(zero(NT), nu)
     c_Δumin,    c_Δumax = fill(zero(NT), nu), fill(zero(NT), nu)
     c_ymin,     c_ymax  = fill(one(NT), ny),  fill(one(NT), ny)
@@ -909,20 +918,25 @@ function init_defaultcon_mpc(
     W̄d = sparse(repeatdiag(Wd, Hp+1))
     W̄r = sparse(repeatdiag(Wr, Hp+1))
     A_Umin,  A_Umax, P̃u  = relaxU(Pu, C_umin, C_umax, nϵ)
-    A_ΔŨmin, A_ΔŨmax, ΔŨmin, ΔŨmax, P̃Δu = relaxΔU(PΔu, C_Δumin, C_Δumax, ΔUmin, ΔUmax, nϵ)
+    A_ΔUmin, A_ΔUmax, P̃Δu = relaxΔU(PΔu, C_Δumin, C_Δumax, nϵ)
     A_Ymin,  A_Ymax, Ẽ  = relaxŶ(E, C_ymin, C_ymax, nϵ)
     A_Wmin,  A_Wmax, Ẽw = relaxW(E, Pu, Hp, W̄y, W̄u, C_wmin, C_wmax, nϵ)
     A_x̂min,  A_x̂max, ẽx̂ = relaxterminal(ex̂, c_x̂min, c_x̂max, nϵ)
     Aeq, ẼS = augmentdefect(ES, nϵ)
     i_Umin,  i_Umax  = .!isinf.(U0min), .!isinf.(U0max)
-    i_ΔŨmin, i_ΔŨmax = .!isinf.(ΔŨmin), .!isinf.(ΔŨmax)
+    i_ΔUmin, i_ΔUmax = .!isinf.(ΔUmin), .!isinf.(ΔUmax)
     i_Ymin,  i_Ymax  = .!isinf.(Y0min), .!isinf.(Y0max)
     i_Wmin,  i_Wmax  = .!isinf.(Wmin),  .!isinf.(Wmax)
     i_x̂min,  i_x̂max  = .!isinf.(x̂0min), .!isinf.(x̂0max)
+    box_constraints_mpc!(
+        Z̃min, Z̃max, transcription, nϵ,
+        ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
+        A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
+    ) 
     i_b, i_g, A, Aeq, neq = init_matconstraint_mpc(
         model, transcription, nc,
-        i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
-        A_Umin, A_Umax, A_ΔŨmin, A_ΔŨmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂max, A_x̂min,
+        i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+        A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂max, A_x̂min,
         Aeq
     )
     # dummy fx̂, Fw and FS vectors (updated just before optimization)
@@ -933,9 +947,10 @@ function init_defaultcon_mpc(
         ẽx̂      , fx̂     , gx̂      , jx̂       , kx̂     , vx̂     , bx̂     ,
         ẼS      , FS     , GS      , JS       , KS     , VS     , BS     ,
         Ẽw      , Fw     , W̄y      , W̄u       , W̄d     , W̄r     , nw     ,
-        U0min   , U0max  , ΔŨmin   , ΔŨmax    , 
+        U0min   , U0max  , ΔUmin   , ΔUmax    , 
         Y0min   , Y0max  , Wmin    , Wmax     , x̂0min  , x̂0max  , 
-        A_Umin  , A_Umax , A_ΔŨmin , A_ΔŨmax  , 
+        Z̃min    , Z̃max   ,
+        A_Umin  , A_Umax , A_ΔUmin , A_ΔUmax  , 
         A_Ymin  , A_Ymax , A_Wmin  , A_Wmax   , A_x̂min , A_x̂max , 
         A       , b      , i_b     , 
         Aeq     , beq    ,
@@ -945,6 +960,19 @@ function init_defaultcon_mpc(
         gc!     , nc
     )
     return con, nϵ, P̃Δu, P̃u, Ẽ
+end
+
+function init_boxconstraints_mpc(i_ΔUmin, i_ΔUmax, A_ΔUmin, A_ΔUmax, nϵ)
+    if nϵ > 0 # input increment bounds are box constraints if hard (instead of linear):
+        n_C_Δumin = @views A_ΔUmin[:, end]
+        n_C_Δumax = @views A_ΔUmax[:, end]
+        i_ΔUmin  .= @. i_ΔUmin & (n_C_Δumin < 0) 
+        i_ΔUmax  .= @. i_ΔUmax & (n_C_Δumax < 0)
+    end
+    println(i_ΔUmin)
+    println(i_ΔUmax)
+
+    return Z̃min, Z̃max
 end
 
 "Repeat predictive controller constraints over their respective horizons."
@@ -997,7 +1025,7 @@ function relaxU(Pu::AbstractMatrix{NT}, C_umin, C_umax, nϵ) where NT<:Real
 end
 
 @doc raw"""
-    relaxΔU(PΔu, C_Δumin, C_Δumax, ΔUmin, ΔUmax, nϵ) -> A_ΔŨmin, A_ΔŨmax, ΔŨmin, ΔŨmax, P̃Δu
+    relaxΔU(PΔu, C_Δumin, C_Δumax, nϵ) -> A_ΔUmin, A_ΔUmax, P̃Δu
 
 Augment input increments constraints with slack variable ϵ for softening.
 
@@ -1006,38 +1034,28 @@ Denoting the decision variables augmented with the slack variable
 augmented conversion matrix ``\mathbf{P̃_{Δu}}``, similar to the one described at
 [`init_ZtoΔU`](@ref), but extracting the input increments augmented with the slack variable
 ``\mathbf{ΔŨ} = [\begin{smallmatrix} \mathbf{ΔU} \\ ϵ \end{smallmatrix}] = \mathbf{P̃_{Δu} Z̃}``.
-Also, knowing that ``0 ≤ ϵ ≤ ∞``, it also returns the augmented bounds 
-``\mathbf{ΔŨ_{min}} = [\begin{smallmatrix} \mathbf{ΔU_{min}} \\ 0 \end{smallmatrix}]`` and
-``\mathbf{ΔŨ_{max}} = [\begin{smallmatrix} \mathbf{ΔU_{min}} \\ ∞ \end{smallmatrix}]``,
-and the ``\mathbf{A}`` matrices for the inequality constraints:
+It also returns the ``\mathbf{A}`` matrices for the inequality constraints:
 ```math
 \begin{bmatrix} 
-    \mathbf{A_{ΔŨ_{min}}} \\ 
-    \mathbf{A_{ΔŨ_{max}}}
+    \mathbf{A_{ΔU_{min}}} \\ 
+    \mathbf{A_{ΔU_{max}}}
 \end{bmatrix} \mathbf{Z̃} ≤
 \begin{bmatrix}
-    - \mathbf{ΔŨ_{min}} \\
-    + \mathbf{ΔŨ_{max}}
+    - \mathbf{ΔU_{min}} \\
+    + \mathbf{ΔU_{max}}
 \end{bmatrix}
 ```
-Note that strictly speaking, the lower bound on the slack variable ϵ is a decision variable
-bound, which is more precise than a linear inequality constraint. However, it is more
-convenient to treat it as a linear inequality constraint since the optimizer `OSQP.jl` does
-not support pure bounds on the decision variables.
 """
-function relaxΔU(PΔu::AbstractMatrix{NT}, C_Δumin, C_Δumax, ΔUmin, ΔUmax, nϵ) where NT<:Real
+function relaxΔU(PΔu::AbstractMatrix{NT}, C_Δumin, C_Δumax, nϵ) where NT<:Real
     nZ = size(PΔu, 2)
     if nϵ == 1 # Z̃ = [Z; ϵ]
-        ΔŨmin, ΔŨmax = [ΔUmin; NT[0.0]], [ΔUmax; NT[Inf]] # 0 ≤ ϵ ≤ ∞
-        A_ϵ = [zeros(NT, 1, nZ) NT[1.0]]
-        A_ΔŨmin, A_ΔŨmax = -[PΔu  C_Δumin; A_ϵ], [PΔu -C_Δumax; A_ϵ]
+        A_ΔUmin, A_ΔUmax = -[PΔu  C_Δumin], [PΔu -C_Δumax]
         P̃Δu = [PΔu zeros(NT, size(PΔu, 1), 1); zeros(NT, 1, size(PΔu, 2)) NT[1.0]]
     else # Z̃ = Z (only hard constraints)
-        ΔŨmin, ΔŨmax = ΔUmin, ΔUmax
-        A_ΔŨmin, A_ΔŨmax = -PΔu,  PΔu
+        A_ΔUmin, A_ΔUmax = -PΔu, PΔu
         P̃Δu = PΔu
     end
-    return A_ΔŨmin, A_ΔŨmax, ΔŨmin, ΔŨmax, P̃Δu
+    return A_ΔUmin, A_ΔUmax, P̃Δu
 end
 
 @doc raw"""

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -348,9 +348,9 @@ function setconstraint!(
     ΔUmin   = DeltaUmin,   ΔUmax = DeltaUmax,
     C_Δumin = C_Deltaumin, C_Δumax = C_Deltaumax,
 )
-    model, con =  mpc.estim.model, mpc.con
+    model, estim, con =  mpc.estim.model, mpc.estim, mpc.con
     transcription, optim = mpc.transcription, mpc.optim
-    nu, ny, nx̂, Hp, Hc = model.nu, model.ny, mpc.estim.nx̂, mpc.Hp, mpc.Hc
+    nu, ny, nx̂, Hp, Hc = model.nu, model.ny, estim.nx̂, mpc.Hp, mpc.Hc
     nϵ, nw, nc = mpc.nϵ, con.nw, con.nc
     notSolvedYet = (JuMP.termination_status(optim) == JuMP.OPTIMIZE_NOT_CALLED)
     if isnothing(Umin) && !isnothing(umin)
@@ -513,14 +513,14 @@ function setconstraint!(
     i_Ymin,  i_Ymax  = .!isinf.(con.Y0min), .!isinf.(con.Y0max)
     i_Wmin,  i_Wmax  = .!isinf.(con.Wmin),  .!isinf.(con.Wmax)
     i_x̂min,  i_x̂max  = .!isinf.(con.x̂0min), .!isinf.(con.x̂0max)
-    box_constraints_mpc!(
-        con.Z̃min, con.Z̃max, transcription, nϵ,
-        con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
+    Z̃min, Z̃max = init_boxconstraint_mpc(
+        estim, transcription, Hp, Hc, nϵ,
+        con.ΔUmin  , con.ΔUmax  , con.x̂0min , con.x̂0max , 
         con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
     )
     if notSolvedYet
         con.i_b[:], con.i_g[:], con.A[:] = init_matconstraint_mpc(
-            model, transcription, nc,
+            model, transcription, Z̃min, Z̃max, nc, nϵ,
             i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
             i_Ymin, i_Ymax, i_Wmin, i_Wmax,
             i_x̂min, i_x̂max,
@@ -529,6 +529,7 @@ function setconstraint!(
             con.A_x̂min, con.A_x̂max,
             con.Aeq
         )
+        con.Z̃min[:], con.Z̃max[:] = Z̃min, Z̃max
         A = con.A[con.i_b, :]
         b = con.b[con.i_b]
         Z̃var::Vector{JuMP.VariableRef} = optim[:Z̃var]
@@ -538,17 +539,22 @@ function setconstraint!(
         reset_nonlincon!(mpc)
     else
         i_b, i_g = init_matconstraint_mpc(
-            model, transcription, nc,
+            model, transcription, Z̃min, Z̃max, nc, nϵ,
             i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
             i_Ymin, i_Ymax, i_Wmin, i_Wmax,
             i_x̂min, i_x̂max,
         )
-        if i_b ≠ con.i_b || i_g ≠ con.i_g
+        diff_Z̃min, diff_Z̃max = diff_infs(Z̃min, con.Z̃min), diff_infs(Z̃max, con.Z̃max)
+        if i_b ≠ con.i_b || i_g ≠ con.i_g || diff_Z̃min || diff_Z̃max
             error("Cannot modify ±Inf constraints after calling moveinput!")
         end
+        con.Z̃min[:], con.Z̃max[:] = Z̃min, Z̃max
     end
     return mpc
 end
+
+"Verify that the `Inf` values in `Z̃new` are the same that in `Z̃old`."
+diff_infs(Z̃new, Z̃old) = any(isinf(x) ≠ isinf(y) for (x,y) in zip(Z̃new, Z̃old))
 
 "By default, no nonlinear constraints, return nothing."
 reset_nonlincon!(::PredictiveController) = nothing
@@ -893,13 +899,11 @@ function init_defaultcon_mpc(
     nW = nw*(Hp+1)
     nS = size(ES, 1)
     nϵ = weights.isinf_C ? 0 : 1
-    nZ̃ = get_nZ(estim, transcription, Hp, Hc) + nϵ
     u0min,      u0max   = fill(convert(NT,-Inf), nu), fill(convert(NT,+Inf), nu)
     Δumin,      Δumax   = fill(convert(NT,-Inf), nu), fill(convert(NT,+Inf), nu)
     y0min,      y0max   = fill(convert(NT,-Inf), ny), fill(convert(NT,+Inf), ny)
     wmin,       wmax    = fill(convert(NT,-Inf), nw), fill(convert(NT,+Inf), nw)
     x̂0min,      x̂0max   = fill(convert(NT,-Inf), nx̂), fill(convert(NT,+Inf), nx̂)
-    Z̃min,       Z̃max    = fill(convert(NT,-Inf), nZ̃), fill(convert(NT,+Inf), nZ̃)
     c_umin,     c_umax  = fill(zero(NT), nu), fill(zero(NT), nu)
     c_Δumin,    c_Δumax = fill(zero(NT), nu), fill(zero(NT), nu)
     c_ymin,     c_ymax  = fill(one(NT), ny),  fill(one(NT), ny)
@@ -928,13 +932,13 @@ function init_defaultcon_mpc(
     i_Ymin,  i_Ymax  = .!isinf.(Y0min), .!isinf.(Y0max)
     i_Wmin,  i_Wmax  = .!isinf.(Wmin),  .!isinf.(Wmax)
     i_x̂min,  i_x̂max  = .!isinf.(x̂0min), .!isinf.(x̂0max)
-    box_constraints_mpc!(
-        Z̃min, Z̃max, transcription, nϵ,
+    Z̃min, Z̃max = init_boxconstraint_mpc(
+        estim, transcription, Hp, Hc, nϵ,
         ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
         A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
-    ) 
+    )
     i_b, i_g, A, Aeq, neq = init_matconstraint_mpc(
-        model, transcription, nc,
+        model, transcription, Z̃min, Z̃max, nc, nϵ,
         i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
         A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂max, A_x̂min,
         Aeq
@@ -960,19 +964,6 @@ function init_defaultcon_mpc(
         gc!     , nc
     )
     return con, nϵ, P̃Δu, P̃u, Ẽ
-end
-
-function init_boxconstraints_mpc(i_ΔUmin, i_ΔUmax, A_ΔUmin, A_ΔUmax, nϵ)
-    if nϵ > 0 # input increment bounds are box constraints if hard (instead of linear):
-        n_C_Δumin = @views A_ΔUmin[:, end]
-        n_C_Δumax = @views A_ΔUmax[:, end]
-        i_ΔUmin  .= @. i_ΔUmin & (n_C_Δumin < 0) 
-        i_ΔUmax  .= @. i_ΔUmax & (n_C_Δumax < 0)
-    end
-    println(i_ΔUmin)
-    println(i_ΔUmax)
-
-    return Z̃min, Z̃max
 end
 
 "Repeat predictive controller constraints over their respective horizons."

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -508,24 +508,19 @@ function setconstraint!(
             size(con.A_x̂max, 1) ≠ 0 && (con.A_x̂max[:, end] .= -con.c_x̂max) # for LinModel
         end
     end
-    i_Umin,  i_Umax  = .!isinf.(con.U0min), .!isinf.(con.U0max)
-    i_ΔUmin, i_ΔUmax = .!isinf.(con.ΔUmin), .!isinf.(con.ΔUmax)
-    i_Ymin,  i_Ymax  = .!isinf.(con.Y0min), .!isinf.(con.Y0max)
-    i_Wmin,  i_Wmax  = .!isinf.(con.Wmin),  .!isinf.(con.Wmax)
-    i_x̂min,  i_x̂max  = .!isinf.(con.x̂0min), .!isinf.(con.x̂0max)
     Z̃min, Z̃max = init_boxconstraint_mpc(
         estim, transcription, Hp, Hc, nϵ,
-        con.ΔUmin  , con.ΔUmax  , con.x̂0min , con.x̂0max , 
+        con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
         con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
     )
     if notSolvedYet
         con.i_b[:], con.i_g[:], con.A[:] = init_matconstraint_mpc(
             model, transcription, Z̃min, Z̃max, nc, nϵ,
-            i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
-            i_Ymin, i_Ymax, i_Wmin, i_Wmax,
-            i_x̂min, i_x̂max,
+            con.U0min,  con.U0max,  con.ΔUmin,   con.ΔUmax,   
+            con.Y0min,  con.Y0max,  con.Wmin,    con.Wmax,   
+            con.x̂0min,  con.x̂0max,
             con.A_Umin, con.A_Umax, con.A_ΔUmin, con.A_ΔUmax, 
-            con.A_Ymin, con.A_Ymax, con.A_Wmin, con.A_Wmax,
+            con.A_Ymin, con.A_Ymax, con.A_Wmin,  con.A_Wmax,
             con.A_x̂min, con.A_x̂max,
             con.Aeq
         )
@@ -546,9 +541,9 @@ function setconstraint!(
     else
         i_b, i_g = init_matconstraint_mpc(
             model, transcription, Z̃min, Z̃max, nc, nϵ,
-            i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, 
-            i_Ymin, i_Ymax, i_Wmin, i_Wmax,
-            i_x̂min, i_x̂max,
+            con.U0min,  con.U0max,  con.ΔUmin,   con.ΔUmax,   
+            con.Y0min,  con.Y0max,  con.Wmin,    con.Wmax,   
+            con.x̂0min,  con.x̂0max
         )
         diff_Z̃min, diff_Z̃max = diff_infs(Z̃min, con.Z̃min), diff_infs(Z̃max, con.Z̃max)
         if i_b ≠ con.i_b || i_g ≠ con.i_g || diff_Z̃min || diff_Z̃max
@@ -933,19 +928,13 @@ function init_defaultcon_mpc(
     A_Wmin,  A_Wmax, Ẽw = relaxW(E, Pu, Hp, W̄y, W̄u, C_wmin, C_wmax, nϵ)
     A_x̂min,  A_x̂max, ẽx̂ = relaxterminal(ex̂, c_x̂min, c_x̂max, nϵ)
     Aeq, ẼS = augmentdefect(ES, nϵ)
-    i_Umin,  i_Umax  = .!isinf.(U0min), .!isinf.(U0max)
-    i_ΔUmin, i_ΔUmax = .!isinf.(ΔUmin), .!isinf.(ΔUmax)
-    i_Ymin,  i_Ymax  = .!isinf.(Y0min), .!isinf.(Y0max)
-    i_Wmin,  i_Wmax  = .!isinf.(Wmin),  .!isinf.(Wmax)
-    i_x̂min,  i_x̂max  = .!isinf.(x̂0min), .!isinf.(x̂0max)
     Z̃min, Z̃max = init_boxconstraint_mpc(
         estim, transcription, Hp, Hc, nϵ,
-        ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
-        A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
+        ΔUmin, ΔUmax, x̂0min, x̂0max, A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
     )
     i_b, i_g, A, Aeq, neq = init_matconstraint_mpc(
         model, transcription, Z̃min, Z̃max, nc, nϵ,
-        i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+        U0min,  U0max,  ΔUmin,   ΔUmax,   Y0min,  Y0max,  Wmin,   Wmax,   x̂0min,  x̂0max,
         A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂max, A_x̂min,
         Aeq
     )
@@ -1229,6 +1218,41 @@ function augmentdefect(ES::AbstractMatrix{NT}, nϵ) where NT<:Real
     end
     Aeq = ẼS
     return Aeq, ẼS
+end
+
+"""
+    init_boxconstraints_mpc(
+        estim::StateEstimator, transcription::TranscriptionMethod, Hp, Hc, nϵ,
+        ΔUmin, ΔUmax, x̂0min, x̂0max, A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
+    ) -> Z̃min, Z̃max
+
+Init the decision variable box constraints `Z̃min` and `Z̃max`.
+"""
+function init_boxconstraint_mpc(
+    estim::StateEstimator{NT}, transcription::TranscriptionMethod, Hp, Hc, nϵ,
+    ΔUmin, ΔUmax, x̂0min, x̂0max, A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max
+) where {NT<:Real}
+    nΔU, nX̂ = estim.model.nu*Hc, estim.nx̂*Hp
+    nZ̃ = get_nZ(estim, transcription, Hp, Hc) + nϵ
+    Z̃min, Z̃max = fill(convert(NT,-Inf), nZ̃), fill(convert(NT,+Inf), nZ̃)
+    nϵ > 0 && (Z̃min[end] = 0)
+    if nϵ > 0
+        n_C_Δumin = @views A_ΔUmin[:, end]
+        n_C_Δumax = @views A_ΔUmax[:, end]
+        for i in eachindex(ΔUmin)
+            iszero(n_C_Δumin[i]) && (Z̃min[i] = ΔUmin[i])
+        end
+        for i in eachindex(ΔUmax)
+            iszero(n_C_Δumax[i]) && (Z̃max[i] = ΔUmax[i])
+        end
+    else
+        Z̃min[1:nΔU] .= ΔUmin
+        Z̃max[1:nΔU] .= ΔUmax
+    end
+    Z̃min, Z̃max = boxconstraint_terminal!(
+        Z̃min, Z̃max, transcription, nΔU, nX̂, nϵ, x̂0min, x̂0max, A_x̂min, A_x̂max
+    )
+    return Z̃min, Z̃max
 end
 
 @doc raw"""

--- a/src/controller/construct.jl
+++ b/src/controller/construct.jl
@@ -534,8 +534,8 @@ function setconstraint!(
         for i in eachindex(Z̃var)
             JuMP.has_lower_bound(Z̃var[i]) && JuMP.delete_lower_bound(Z̃var[i])
             JuMP.has_upper_bound(Z̃var[i]) && JuMP.delete_upper_bound(Z̃var[i])
-            !isinf(con.Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], con.Z̃min[i])
-            !isinf(con.Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], con.Z̃max[i])
+            !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])
+            !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i])
         end
         reset_nonlincon!(mpc)
     else
@@ -550,6 +550,10 @@ function setconstraint!(
             error("Cannot modify ±Inf constraints after calling moveinput!")
         end
         con.Z̃min[:], con.Z̃max[:] = Z̃min, Z̃max
+        for i in eachindex(Z̃var)
+            !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], con.Z̃min[i])
+            !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], con.Z̃max[i])
+        end
     end
     return mpc
 end

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -792,6 +792,8 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
         con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
         con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
     )
+    con.Z̃min .= Z̃min
+    con.Z̃max .= Z̃max
     # --- quadratic programming Hessian matrix ---
     # do not verify the condition number of the Hessian here:
     H̃ = init_quadprog(model, transcription, weights, mpc.Ẽ, mpc.P̃Δu, mpc.P̃u; warn_cond=Inf)
@@ -805,8 +807,7 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
     JuMP.unregister(optim, :linconstraint)
     @constraint(optim, linconstraint, A*Z̃var .≤ b)
     for i in eachindex(Z̃var)
-        JuMP.has_lower_bound(Z̃var[i]) && JuMP.delete_lower_bound(Z̃var[i])
-        JuMP.has_upper_bound(Z̃var[i]) && JuMP.delete_upper_bound(Z̃var[i])
+        # deletion not required here since changing op. pts won't change finite status
         !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])
         !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i])
     end

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -496,7 +496,7 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     model, optim = mpc.estim.model, mpc.optim
     Z̃var::Vector{JuMP.VariableRef} = optim[:Z̃var]
     Z̃s = set_warmstart!(mpc, mpc.transcription, Z̃var)
-    set_objective_linear_coef!(mpc, model, Z̃var)
+    set_variable_attributes!(mpc, model, Z̃var)
     try
         JuMP.optimize!(optim)
     catch err
@@ -533,14 +533,31 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     return mpc.Z̃
 end
 
-"By default, no need to update the objective function."
-set_objective_linear_coef!(::PredictiveController, ::SimModel, _ ) = nothing
+"""
+    set_variable_attributes!(mpc::PredictiveController, model::SimModel, Z̃var)
 
-"Update the linear coefficients of the quadratic objective with `mpc.q̃` if applicable."
-function set_objective_linear_coef!(mpc::PredictiveController, ::LinModel, Z̃var)
+Update the box constraint bounds on the decision variable `Z̃var`.
+"""
+function set_variable_attributes!(mpc::PredictiveController, ::SimModel, Z̃var)
+    Z̃min, Z̃max = mpc.con.Z̃min, mpc.con.Z̃max
+    foreach(i -> !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i]), eachindex(Z̃min))
+    foreach(i -> !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i]), eachindex(Z̃max))
+    return nothing
+end
+
+"""
+    set_variable_attributes!(mpc::PredictiveController, model::LinModel, Z̃var)
+
+Also update the linear coefficients of the quadratic objective with `mpc.q̃` if applicable.
+"""
+function set_variable_attributes!(mpc::PredictiveController, ::LinModel, Z̃var)
+    Z̃min, Z̃max = mpc.con.Z̃min, mpc.con.Z̃max
+    foreach(i -> !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i]), eachindex(Z̃min))
+    foreach(i -> !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i]), eachindex(Z̃max))
     mpc.weights.iszero_E && JuMP.set_objective_coefficient(mpc.optim, Z̃var, mpc.q̃)
     return nothing
 end
+
 
 """
     preparestate!(mpc::PredictiveController, ym, d=[]) -> x̂

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -786,6 +786,12 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
     con.Y0max .-= mpc.Yop # convert Y to Y0 with the new operating point
     con.x̂0min .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
     con.x̂0max .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
+    # --- box constraints ---
+    Z̃min, Z̃max = init_boxconstraint_mpc(
+        estim, transcription, Hp, Hc, mpc.nϵ,
+        con.ΔUmin, con.ΔUmax, con.x̂0min, con.x̂0max, 
+        con.A_ΔUmin, con.A_ΔUmax, con.A_x̂min, con.A_x̂max 
+    )
     # --- quadratic programming Hessian matrix ---
     # do not verify the condition number of the Hessian here:
     H̃ = init_quadprog(model, transcription, weights, mpc.Ẽ, mpc.P̃Δu, mpc.P̃u; warn_cond=Inf)
@@ -798,6 +804,12 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
     JuMP.delete(optim, optim[:linconstraint])
     JuMP.unregister(optim, :linconstraint)
     @constraint(optim, linconstraint, A*Z̃var .≤ b)
+    for i in eachindex(Z̃var)
+        JuMP.has_lower_bound(Z̃var[i]) && JuMP.delete_lower_bound(Z̃var[i])
+        JuMP.has_upper_bound(Z̃var[i]) && JuMP.delete_upper_bound(Z̃var[i])
+        !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])
+        !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i])
+    end
     JuMP.delete(optim, optim[:linconstrainteq])
     JuMP.unregister(optim, :linconstrainteq)
     @constraint(optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -496,7 +496,7 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     model, optim = mpc.estim.model, mpc.optim
     Z̃var::Vector{JuMP.VariableRef} = optim[:Z̃var]
     Z̃s = set_warmstart!(mpc, mpc.transcription, Z̃var)
-    set_variable_attributes!(mpc, model, Z̃var)
+    set_objective_linear_coef!(mpc, model, Z̃var)
     try
         JuMP.optimize!(optim)
     catch err
@@ -533,27 +533,12 @@ function optim_objective!(mpc::PredictiveController{NT}) where {NT<:Real}
     return mpc.Z̃
 end
 
-"""
-    set_variable_attributes!(mpc::PredictiveController, model::SimModel, Z̃var)
 
-Update the box constraint bounds on the decision variable `Z̃var`.
-"""
-function set_variable_attributes!(mpc::PredictiveController, ::SimModel, Z̃var)
-    Z̃min, Z̃max = mpc.con.Z̃min, mpc.con.Z̃max
-    foreach(i -> !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i]), eachindex(Z̃min))
-    foreach(i -> !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i]), eachindex(Z̃max))
-    return nothing
-end
+"By default, no need to update the objective function."
+set_objective_linear_coef!(::PredictiveController, ::SimModel, _) = nothing
 
-"""
-    set_variable_attributes!(mpc::PredictiveController, model::LinModel, Z̃var)
-
-Also update the linear coefficients of the quadratic objective with `mpc.q̃` if applicable.
-"""
-function set_variable_attributes!(mpc::PredictiveController, ::LinModel, Z̃var)
-    Z̃min, Z̃max = mpc.con.Z̃min, mpc.con.Z̃max
-    foreach(i -> !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i]), eachindex(Z̃min))
-    foreach(i -> !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i]), eachindex(Z̃max))
+"Update the linear coefficients of the quadratic objective with `mpc.q̃` for `LinModel`."
+function set_objective_linear_coef!(mpc::PredictiveController, ::LinModel, Z̃var)
     mpc.weights.iszero_E && JuMP.set_objective_coefficient(mpc.optim, Z̃var, mpc.q̃)
     return nothing
 end

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -756,8 +756,8 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
     con.A .= [
         con.A_Umin
         con.A_Umax 
-        con.A_ΔŨmin 
-        con.A_ΔŨmax 
+        con.A_ΔUmin 
+        con.A_ΔUmax 
         con.A_Ymin  
         con.A_Ymax 
         con.A_x̂min  

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -243,7 +243,7 @@ function LinMPC(
     Wr = nothing,
     Cwt = DEFAULT_CWT,
     transcription::ShootingMethod = DEFAULT_LINMPC_TRANSCRIPTION,
-    optim::JuMP.GenericModel = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=false),
+    optim::JuMP.GenericModel = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=true),
     kwargs...
 )
     estim = SteadyKalmanFilter(model; kwargs...)
@@ -302,7 +302,7 @@ function LinMPC(
     Wr = nothing,
     Cwt  = DEFAULT_CWT,
     transcription::ShootingMethod = DEFAULT_LINMPC_TRANSCRIPTION,
-    optim::JM = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=false)
+    optim::JM = JuMP.Model(DEFAULT_LINMPC_OPTIMIZER, add_bridges=true)
 ) where {NT<:Real, SE<:StateEstimator{NT}, JM<:JuMP.GenericModel}
     isa(estim.model, LinModel) || error(MSG_LINMODEL_ERR) 
     nk = estimate_delays(estim.model)
@@ -328,7 +328,7 @@ function init_optimization!(mpc::LinMPC, model::LinModel, optim::JuMP.GenericMod
     JuMP.num_variables(optim) == 0 || JuMP.empty!(optim)
     JuMP.set_silent(optim)
     limit_solve_time(mpc.optim, model.Ts)
-    @variable(optim, Z̃var[1:nZ̃])
+    @variable(optim, con.Z̃min[i] ≤ Z̃var[i=1:nZ̃] ≤ con.Z̃max[i])
     A = con.A[con.i_b, :]
     b = con.b[con.i_b]
     @constraint(optim, linconstraint, A*Z̃var .≤ b)

--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -192,7 +192,7 @@ LinMPC controller with a sample time Ts = 4.0 s:
   │ └  0 measured disturbances d
   └ optimization:
     ├ 2 decision variables Z̃ (1 slack variable)
-    ├ 1 linear inequality constraints A (0 custom)
+    ├ 0 linear inequality constraints A (0 custom)
     └ 0 linear equality constraints Aeq
 ```
 
@@ -282,7 +282,7 @@ LinMPC controller with a sample time Ts = 4.0 s:
   │ └  0 measured disturbances d
   └ optimization:
     ├ 2 decision variables Z̃ (1 slack variable)
-    ├ 1 linear inequality constraints A (0 custom)
+    ├ 0 linear inequality constraints A (0 custom)
     └ 0 linear equality constraints Aeq
 ```
 """

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -750,7 +750,7 @@ function init_optimization!(mpc::NonLinMPC, model::SimModel, optim::JuMP.Generic
     JuMP.num_variables(optim) == 0 || JuMP.empty!(optim)
     JuMP.set_silent(optim)
     limit_solve_time(mpc.optim, model.Ts)
-    @variable(optim, Z̃var[1:nZ̃])
+    @variable(optim, con.Z̃min[i] ≤ Z̃var[i=1:nZ̃] ≤ con.Z̃max[i])
     A = con.A[con.i_b, :]
     b = con.b[con.i_b]
     @constraint(optim, linconstraint, A*Z̃var .≤ b)

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -236,8 +236,8 @@ This controller allocates memory at each time step for the optimization.
 - `hessian=false` : an `AbstractADType` backend or `Bool` for the Hessian of the Lagrangian, 
    see `gradient` above for the options. The default `false` skip it and use the
    quasi-Newton method of `optim` (see Extended Help).
-- additional keyword arguments are passed to [`UnscentedKalmanFilter`](@ref) constructor 
-  (or [`SteadyKalmanFilter`](@ref), for [`LinModel`](@ref)).
+-  additional keyword arguments are passed to [`UnscentedKalmanFilter`](@ref) constructor 
+   (or [`SteadyKalmanFilter`](@ref), for [`LinModel`](@ref)).
 
 # Examples
 ```jldoctest

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -262,7 +262,7 @@ NonLinMPC controller with a sample time Ts = 10.0 s:
   │ └  0 measured disturbances d
   └ optimization:
     ├ 51 decision variables Z̃ (1 slack variable)
-    ├  1 linear inequality constraints A (0 custom)
+    ├  0 linear inequality constraints A (0 custom)
     ├ 20 linear equality constraints Aeq
     ├  0 nonlinear inequality constraints g (0 custom)
     └ 20 nonlinear equality constraints geq
@@ -410,7 +410,7 @@ NonLinMPC controller with a sample time Ts = 10.0 s:
   │ └  0 measured disturbances d
   └ optimization:
     ├ 3 decision variables Z̃ (1 slack variable)
-    ├ 1 linear inequality constraints A (0 custom)
+    ├ 0 linear inequality constraints A (0 custom)
     ├ 0 linear equality constraints Aeq
     ├ 0 nonlinear inequality constraints g (0 custom)
     └ 0 nonlinear equality constraints geq

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -966,7 +966,7 @@ function boxconstraint_terminal!(
     end
     return Z̃min, Z̃max
 end
-boxconstraint_terminal!(Z̃min, Z̃max, ::SingleShooting, _ , _ , _ , _ ) = Z̃min, Z̃max
+boxconstraint_terminal!(Z̃min, Z̃max, ::SingleShooting, _, _ , _, _, _, _, _) = Z̃min, Z̃max
 
 "Unset `i_ΔUmin` and `i_ΔUmax` elements if finite box constraints in `Z̃min` and `Z̃max`."
 function deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, ::SimModel, ::TranscriptionMethod, Z̃min, Z̃max)

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -873,7 +873,7 @@ function init_matconstraint_mpc(
             A_Umin;  A_Umax; 
             A_ΔUmin; A_ΔUmax; 
             A_Ymin;  A_Ymax; 
-            A_Wmin;  A_Wmax
+            A_Wmin;  A_Wmax;
             A_x̂min;  A_x̂max;
         ]
         neq = 0 # number of nonlinear equality constraints
@@ -961,7 +961,7 @@ function boxconstraint_terminal!(
             iszero(n_C_x̂max[i]) && (Z̃max[i_base + i] = x̂0max[i])
         end
     else
-        Z̃max[i_base+1:i_base+nx̂] .= x̂0min
+        Z̃min[i_base+1:i_base+nx̂] .= x̂0min
         Z̃max[i_base+1:i_base+nx̂] .= x̂0max
     end
     return Z̃min, Z̃max

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -827,10 +827,46 @@ function init_defectmat_empty(
     return ES, GS, JS, KS, VS, BS
 end
 
+"""
+    box_constraints_mpc!(
+        Z̃min, Z̃max, transcription::TranscriptionMethod, nϵ
+        ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
+        A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
+    ) -> Z̃min, Z̃max
+
+Fill in-place the decision variable box constraints `Z̃min` and `Z̃max`.
+"""
+function box_constraints_mpc!(
+    Z̃min, Z̃max, ::TranscriptionMethod, nϵ,
+    ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
+    A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
+)
+    nΔU = length(ΔUmin)
+    Z̃min .= -Inf
+    Z̃max .=  Inf
+    nϵ > 0 && (Z̃min[end] = 0)
+    if nϵ > 0
+        n_C_Δumin = @views A_ΔUmin[:, end]
+        n_C_Δumax = @views A_ΔUmax[:, end]
+        for i in eachindex(ΔUmin)
+            iszero(n_C_Δumin[i]) && (Z̃min[i] = ΔUmin[i])
+        end
+        for i in eachindex(ΔUmax)
+            iszero(n_C_Δumax[i]) && (Z̃max[i] = ΔUmax[i])
+        end
+    else
+        Z̃min[1:nΔU] .= ΔUmin
+        Z̃max[1:nΔU] .= ΔUmax
+    end
+    println(Z̃min)
+    println(Z̃max)
+    return Z̃min, Z̃max
+end
+
 @doc raw"""
     init_matconstraint_mpc(
         model::LinModel, transcription::TranscriptionMethod, nc::Int,
-        i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+        i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
         args...
     ) -> i_b, i_g, A, Aeq, neq
 
@@ -850,12 +886,12 @@ The argument `nc` is the number of custom nonlinear inequality constraints in
 finite numbers. `i_g` is a similar vector but for the indices of ``\mathbf{g}``. The method
 also returns the ``\mathbf{A, A_{eq}}`` matrices and `neq` if `args` is provided. In such a 
 case, `args`  needs to contain all the inequality and equality constraint matrices: 
-`A_Umin, A_Umax, A_ΔŨmin, A_ΔŨmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂min, A_x̂max, Aeq`. 
+`A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, A_Ymin, A_Ymax, A_Wmin, A_Wmax, A_x̂min, A_x̂max, Aeq`. 
 The integer `neq` is the number of nonlinear equality constraints in ``\mathbf{g_{eq}}``.
 """
 function init_matconstraint_mpc(
     ::LinModel{NT}, ::TranscriptionMethod, nc::Int,
-    i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
     if isempty(args)
@@ -863,7 +899,7 @@ function init_matconstraint_mpc(
     else
         (
             A_Umin,  A_Umax, 
-            A_ΔŨmin, A_ΔŨmax, 
+            A_ΔUmin, A_ΔUmax, 
             A_Ymin,  A_Ymax, 
             A_Wmin,  A_Wmax,
             A_x̂min,  A_x̂max,  
@@ -871,14 +907,14 @@ function init_matconstraint_mpc(
         ) = args
         A = [
             A_Umin;  A_Umax; 
-            A_ΔŨmin; A_ΔŨmax; 
+            A_ΔUmin; A_ΔUmax; 
             A_Ymin;  A_Ymax; 
             A_Wmin;  A_Wmax
             A_x̂min;  A_x̂max;
         ]
         neq = 0 # number of nonlinear equality constraints
     end
-    i_b = [i_Umin; i_Umax; i_ΔŨmin; i_ΔŨmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
+    i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
     i_g = trues(nc)
     return i_b, i_g, A, Aeq, neq
 end
@@ -886,17 +922,17 @@ end
 "Init `i_b` without output & terminal constraints if `NonLinModel` and `SingleShooting`."
 function init_matconstraint_mpc(
     ::NonLinModel{NT}, ::SingleShooting, nc::Int,
-    i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
     if isempty(args)
         A, Aeq, neq = nothing, nothing, nothing
     else
-        A_Umin, A_Umax, A_ΔŨmin, A_ΔŨmax, _ , _ , A_Wmin, A_Wmax, _ , _ , Aeq = args
-        A   = [A_Umin; A_Umax; A_ΔŨmin; A_ΔŨmax; A_Wmin; A_Wmax]
+        A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, _ , _ , A_Wmin, A_Wmax, _ , _ , Aeq = args
+        A   = [A_Umin; A_Umax; A_ΔUmin; A_ΔUmax; A_Wmin; A_Wmax]
         neq = 0 # number of nonlinear equality constraints
     end
-    i_b = [i_Umin; i_Umax; i_ΔŨmin; i_ΔŨmax; i_Wmin; i_Wmax]
+    i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax]
     i_g = [i_Ymin; i_Ymax; i_x̂min;  i_x̂max; trues(nc)]
     return i_b, i_g, A, Aeq, neq
 end
@@ -904,18 +940,18 @@ end
 "Init `i_b` without output constraints if `NonLinModel` and other `TranscriptionMethod`."
 function init_matconstraint_mpc(
     ::NonLinModel{NT}, ::TranscriptionMethod, nc::Int,
-    i_Umin, i_Umax, i_ΔŨmin, i_ΔŨmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
     if isempty(args)
         A, Aeq, neq = nothing, nothing, nothing
     else    
-        A_Umin, A_Umax, A_ΔŨmin, A_ΔŨmax, _ , _ , A_Wmin, A_Wmax, A_x̂min, A_x̂max, Aeq = args
-        A   = [A_Umin; A_Umax; A_ΔŨmin; A_ΔŨmax; A_Wmin; A_Wmax; A_x̂min; A_x̂max]
-        nΔŨ, nZ̃ = size(A_ΔŨmin)
+        A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, _ , _ , A_Wmin, A_Wmax, A_x̂min, A_x̂max, Aeq = args
+        A   = [A_Umin; A_Umax; A_ΔUmin; A_ΔUmax; A_Wmin; A_Wmax; A_x̂min; A_x̂max]
+        nΔŨ, nZ̃ = size(A_ΔUmin)
         neq = nZ̃ - nΔŨ - size(Aeq, 1)  # number of nonlinear equality constraints
     end
-    i_b = [i_Umin; i_Umax; i_ΔŨmin; i_ΔŨmax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
+    i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
     i_g = [i_Ymin; i_Ymax; trues(nc)]
     return i_b, i_g, A, Aeq, neq
 end
@@ -931,7 +967,7 @@ Also init ``\mathbf{f_x̂} = \mathbf{g_x̂ d_0}(k) + \mathbf{j_x̂ D̂_0} + \mat
 also updated, see [`relaxW`](@ref).
 """
 function linconstraint!(mpc::PredictiveController, model::LinModel, ::TranscriptionMethod)
-    nU, nΔŨ, nY = length(mpc.con.U0min), length(mpc.con.ΔŨmin), length(mpc.con.Y0min)
+    nU, nΔŨ, nY = length(mpc.con.U0min), length(mpc.con.ΔUmin), length(mpc.con.Y0min)
     nW = length(mpc.con.Wmin)
     nx̂, fx̂ = mpc.estim.nx̂, mpc.con.fx̂
     fx̂ .= mpc.con.bx̂

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -827,44 +827,10 @@ function init_defectmat_empty(
     return ES, GS, JS, KS, VS, BS
 end
 
-"""
-    init_boxconstraints_mpc(
-        model::StateEstimator, transcription::TranscriptionMethod, Hp, Hc, nϵ,
-        ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
-        A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
-    ) -> Z̃min, Z̃max
-
-Init the decision variable box constraints `Z̃min` and `Z̃max`.
-"""
-function init_boxconstraint_mpc(
-    estim::StateEstimator{NT}, transcription::TranscriptionMethod, Hp, Hc, nϵ,
-    ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
-    A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
-) where {NT<:Real}
-    nΔU = estim.model.nu*Hc
-    nZ̃ = get_nZ(estim, transcription, Hp, Hc) + nϵ
-    Z̃min, Z̃max = fill(convert(NT,-Inf), nZ̃), fill(convert(NT,+Inf), nZ̃)
-    nϵ > 0 && (Z̃min[end] = 0)
-    if nϵ > 0
-        n_C_Δumin = @views A_ΔUmin[:, end]
-        n_C_Δumax = @views A_ΔUmax[:, end]
-        for i in eachindex(ΔUmin)
-            iszero(n_C_Δumin[i]) && (Z̃min[i] = ΔUmin[i])
-        end
-        for i in eachindex(ΔUmax)
-            iszero(n_C_Δumax[i]) && (Z̃max[i] = ΔUmax[i])
-        end
-    else
-        Z̃min[1:nΔU] .= ΔUmin
-        Z̃max[1:nΔU] .= ΔUmax
-    end
-    return Z̃min, Z̃max
-end
-
 @doc raw"""
     init_matconstraint_mpc(
-        model::LinModel, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
-        i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+        model::LinModel, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ 
+        U0min, U0max, ΔUmin, ΔUmax, Y0min, Y0max, Wmin, Wmax, x̂0min, x̂0max,
         args...
     ) -> i_b, i_g, A, Aeq, neq
 
@@ -888,8 +854,8 @@ case, `args`  needs to contain all the inequality and equality constraint matric
 The integer `neq` is the number of nonlinear equality constraints in ``\mathbf{g_{eq}}``.
 """
 function init_matconstraint_mpc(
-    ::LinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
-    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    model::LinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
+    U0min, U0max, ΔUmin, ΔUmax, Y0min, Y0max, Wmin, Wmax, x̂0min, x̂0max,
     args...
 ) where {NT<:Real}
     if isempty(args)
@@ -912,25 +878,23 @@ function init_matconstraint_mpc(
         ]
         neq = 0 # number of nonlinear equality constraints
     end
-    i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
-    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
-    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
+    i_Umin,  i_Umax  = @. !isinf(U0min), !isinf(U0max)
+    i_ΔUmin, i_ΔUmax = @. !isinf(ΔUmin), !isinf(ΔUmax)
+    i_Ymin,  i_Ymax  = @. !isinf(Y0min), !isinf(Y0max)
+    i_Wmin,  i_Wmax  = @. !isinf(Wmin),  !isinf(Wmax)
+    i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
+    nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
+    deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
+    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
+    i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]    
     i_g = trues(nc)
     return i_b, i_g, A, Aeq, neq
 end
 
-function delete_lincon!(i_b, ::TranscriptionMethod, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
-    i_ΔUmin, ΔUmin = @views i_b[2nU+1:2nU+nΔU], Z̃min[1:nΔU]
-    foreach(i -> !isinf(ΔUmin[i]) && (i_ΔUmin[i] = false), eachindex(ΔUmin))
-    i_ΔUmax, ΔUmax = @views i_b[2nU+nΔU+1:2nU+2nΔU], Z̃max[1:nΔU]
-    foreach(i -> !isinf(ΔUmax[i]) && (i_ΔUmax[i] = false), eachindex(ΔUmax))
-    return i_b
-end 
-
 "Init `i_b` without output & terminal constraints if `NonLinModel` and `SingleShooting`."
 function init_matconstraint_mpc(
-    ::NonLinModel{NT}, transcription::SingleShooting, Z̃min, Z̃max, nc, nϵ,
-    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    model::NonLinModel{NT}, transcription::SingleShooting, Z̃min, Z̃max, nc, nϵ,
+    U0min, U0max, ΔUmin, ΔUmax, Y0min, Y0max, Wmin, Wmax, x̂0min, x̂0max,
     args...
 ) where {NT<:Real}
     if isempty(args)
@@ -940,17 +904,23 @@ function init_matconstraint_mpc(
         A   = [A_Umin; A_Umax; A_ΔUmin; A_ΔUmax; A_Wmin; A_Wmax]
         neq = 0 # number of nonlinear equality constraints
     end
+    i_Umin,  i_Umax  = @. !isinf(U0min), !isinf(U0max)
+    i_ΔUmin, i_ΔUmax = @. !isinf(ΔUmin), !isinf(ΔUmax)
+    i_Ymin,  i_Ymax  = @. !isinf(Y0min), !isinf(Y0max)
+    i_Wmin,  i_Wmax  = @. !isinf(Wmin),  !isinf(Wmax)
+    i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
+    nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
+    deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
+    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax]
-    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
-    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
-    i_g = [i_Ymin; i_Ymax; i_x̂min;  i_x̂max; trues(nc)]
+    i_g = [i_Ymin; i_Ymax; i_x̂min; i_x̂max; trues(nc)]
     return i_b, i_g, A, Aeq, neq
 end
 
 "Init `i_b` without output constraints if `NonLinModel` and other `TranscriptionMethod`."
 function init_matconstraint_mpc(
-    ::NonLinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
-    i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
+    model::NonLinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
+    U0min, U0max, ΔUmin, ΔUmax, Y0min, Y0max, Wmin, Wmax, x̂0min, x̂0max,
     args...
 ) where {NT<:Real}
     if isempty(args)
@@ -962,12 +932,60 @@ function init_matconstraint_mpc(
         nAeq = size(Aeq, 1)             # number of linear equality constraint
         neq  = nZ̃ - nΔU - nϵ - nAeq     # number of nonlinear equality constraints
     end
+    i_Umin,  i_Umax  = @. !isinf(U0min), !isinf(U0max)
+    i_ΔUmin, i_ΔUmax = @. !isinf(ΔUmin), !isinf(ΔUmax)
+    i_Ymin,  i_Ymax  = @. !isinf(Y0min), !isinf(Y0max)
+    i_Wmin,  i_Wmax  = @. !isinf(Wmin),  !isinf(Wmax)
+    i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
+    nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
+    deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
+    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
-    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
-    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
     i_g = [i_Ymin; i_Ymax; trues(nc)]
     return i_b, i_g, A, Aeq, neq
 end 
+
+"Modify `Z̃min` and `Z̃max` in-place to include terminal constraint if applicable."
+function boxconstraint_terminal!(
+    Z̃min, Z̃max, ::TranscriptionMethod, nΔU, nX̂, nϵ, x̂0min, x̂0max, A_x̂min, A_x̂max, 
+)
+    nx̂ = length(x̂0min)
+    i_base = nΔU + nX̂ - nx̂
+    if nϵ > 0
+        n_C_x̂min = @views A_x̂min[:, end]
+        n_C_x̂max = @views A_x̂max[:, end]
+        for i in eachindex(x̂0min)
+            iszero(n_C_x̂min[i]) && (Z̃min[i_base + i] = x̂0min[i])
+        end
+        for i in eachindex(x̂0max)
+            iszero(n_C_x̂max[i]) && (Z̃max[i_base + i] = x̂0max[i])
+        end
+    else
+        Z̃max[i_base+1:i_base+nx̂] .= x̂0min
+        Z̃max[i_base+1:i_base+nx̂] .= x̂0max
+    end
+    return Z̃min, Z̃max
+end
+boxconstraint_terminal!(Z̃min, Z̃max, ::SingleShooting, _ , _ , _ , _ ) = Z̃min, Z̃max
+
+"Unset `i_ΔUmin` and `i_ΔUmax` elements if finite box constraints in `Z̃min` and `Z̃max`."
+function deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, ::SimModel, ::TranscriptionMethod, Z̃min, Z̃max)
+    nΔU = length(i_ΔUmin)
+    ΔUmin, ΔUmax = @views Z̃min[1:nΔU], @views Z̃max[1:nΔU]
+    foreach(i -> !isinf(ΔUmin[i]) && (i_ΔUmin[i] = false), eachindex(ΔUmin))
+    foreach(i -> !isinf(ΔUmax[i]) && (i_ΔUmax[i] = false), eachindex(ΔUmax))
+    return i_ΔUmin, i_ΔUmax
+end 
+
+"Unset `i_x̂min` and `i_x̂max` elements if finite box constraints in `Z̃min` and `Z̃max`."
+function deletex̂_lincon!(i_x̂min, i_x̂max, ::SimModel, ::TranscriptionMethod, Z̃min, Z̃max, nΔU, nX̂)
+    nx̂ = length(i_x̂min)
+    x̂0min, x̂0max = @views Z̃min[nΔU+nX̂-nx̂+1:nΔU+nX̂], @views Z̃max[nΔU+nX̂-nx̂+1:nΔU+nX̂]
+    foreach(i -> !isinf(x̂0min[i]) && (i_x̂min[i] = false), eachindex(x̂0min))
+    foreach(i -> !isinf(x̂0max[i]) && (i_x̂max[i] = false), eachindex(x̂0max))
+    return i_x̂min, i_x̂max
+end
+deletex̂_lincon!(i_x̂min, i_x̂max, ::SimModel, ::SingleShooting, _, _, _, _) = i_x̂min, i_x̂max
 
 @doc raw"""
     linconstraint!(mpc::PredictiveController, model::LinModel)

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -885,7 +885,7 @@ function init_matconstraint_mpc(
     i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
     nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
     deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
-    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
+    deletex̂end_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]    
     i_g = trues(nc)
     return i_b, i_g, A, Aeq, neq
@@ -911,7 +911,7 @@ function init_matconstraint_mpc(
     i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
     nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
     deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
-    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
+    deletex̂end_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax]
     i_g = [i_Ymin; i_Ymax; i_x̂min; i_x̂max; trues(nc)]
     return i_b, i_g, A, Aeq, neq
@@ -939,7 +939,7 @@ function init_matconstraint_mpc(
     i_x̂min,  i_x̂max  = @. !isinf(x̂0min), !isinf(x̂0max)
     nΔU, nX̂ = length(ΔUmin), length(x̂0min)*length(Y0min)÷model.ny 
     deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, model, transcription, Z̃min, Z̃max)
-    deletex̂_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
+    deletex̂end_lincon!(i_x̂min, i_x̂max, model, transcription, Z̃min, Z̃max, nΔU, nX̂)
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
     i_g = [i_Ymin; i_Ymax; trues(nc)]
     return i_b, i_g, A, Aeq, neq
@@ -978,14 +978,14 @@ function deleteΔU_lincon!(i_ΔUmin, i_ΔUmax, ::SimModel, ::TranscriptionMethod
 end 
 
 "Unset `i_x̂min` and `i_x̂max` elements if finite box constraints in `Z̃min` and `Z̃max`."
-function deletex̂_lincon!(i_x̂min, i_x̂max, ::SimModel, ::TranscriptionMethod, Z̃min, Z̃max, nΔU, nX̂)
+function deletex̂end_lincon!(i_x̂min, i_x̂max, ::SimModel, ::TranscriptionMethod, Z̃min, Z̃max, nΔU, nX̂)
     nx̂ = length(i_x̂min)
     x̂0min, x̂0max = @views Z̃min[nΔU+nX̂-nx̂+1:nΔU+nX̂], @views Z̃max[nΔU+nX̂-nx̂+1:nΔU+nX̂]
     foreach(i -> !isinf(x̂0min[i]) && (i_x̂min[i] = false), eachindex(x̂0min))
     foreach(i -> !isinf(x̂0max[i]) && (i_x̂max[i] = false), eachindex(x̂0max))
     return i_x̂min, i_x̂max
 end
-deletex̂_lincon!(i_x̂min, i_x̂max, ::SimModel, ::SingleShooting, _, _, _, _) = i_x̂min, i_x̂max
+deletex̂end_lincon!(i_x̂min, i_x̂max, ::SimModel, ::SingleShooting, _, _, _, _) = i_x̂min, i_x̂max
 
 @doc raw"""
     linconstraint!(mpc::PredictiveController, model::LinModel)

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -828,22 +828,22 @@ function init_defectmat_empty(
 end
 
 """
-    box_constraints_mpc!(
-        Z̃min, Z̃max, transcription::TranscriptionMethod, nϵ
+    init_boxconstraints_mpc(
+        model::StateEstimator, transcription::TranscriptionMethod, Hp, Hc, nϵ,
         ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
         A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
     ) -> Z̃min, Z̃max
 
-Fill in-place the decision variable box constraints `Z̃min` and `Z̃max`.
+Init the decision variable box constraints `Z̃min` and `Z̃max`.
 """
-function box_constraints_mpc!(
-    Z̃min, Z̃max, ::TranscriptionMethod, nϵ,
+function init_boxconstraint_mpc(
+    estim::StateEstimator{NT}, transcription::TranscriptionMethod, Hp, Hc, nϵ,
     ΔUmin  , ΔUmax  , x̂0min , x̂0max , 
     A_ΔUmin, A_ΔUmax, A_x̂min, A_x̂max 
-)
-    nΔU = length(ΔUmin)
-    Z̃min .= -Inf
-    Z̃max .=  Inf
+) where {NT<:Real}
+    nΔU = estim.model.nu*Hc
+    nZ̃ = get_nZ(estim, transcription, Hp, Hc) + nϵ
+    Z̃min, Z̃max = fill(convert(NT,-Inf), nZ̃), fill(convert(NT,+Inf), nZ̃)
     nϵ > 0 && (Z̃min[end] = 0)
     if nϵ > 0
         n_C_Δumin = @views A_ΔUmin[:, end]
@@ -858,14 +858,12 @@ function box_constraints_mpc!(
         Z̃min[1:nΔU] .= ΔUmin
         Z̃max[1:nΔU] .= ΔUmax
     end
-    println(Z̃min)
-    println(Z̃max)
     return Z̃min, Z̃max
 end
 
 @doc raw"""
     init_matconstraint_mpc(
-        model::LinModel, transcription::TranscriptionMethod, nc::Int,
+        model::LinModel, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
         i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
         args...
     ) -> i_b, i_g, A, Aeq, neq
@@ -890,7 +888,7 @@ case, `args`  needs to contain all the inequality and equality constraint matric
 The integer `neq` is the number of nonlinear equality constraints in ``\mathbf{g_{eq}}``.
 """
 function init_matconstraint_mpc(
-    ::LinModel{NT}, ::TranscriptionMethod, nc::Int,
+    ::LinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
     i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
@@ -915,13 +913,23 @@ function init_matconstraint_mpc(
         neq = 0 # number of nonlinear equality constraints
     end
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Ymin; i_Ymax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
+    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
+    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
     i_g = trues(nc)
     return i_b, i_g, A, Aeq, neq
 end
 
+function delete_lincon!(i_b, ::TranscriptionMethod, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
+    i_ΔUmin, ΔUmin = @views i_b[2nU+1:2nU+nΔU], Z̃min[1:nΔU]
+    foreach(i -> !isinf(ΔUmin[i]) && (i_ΔUmin[i] = false), eachindex(ΔUmin))
+    i_ΔUmax, ΔUmax = @views i_b[2nU+nΔU+1:2nU+2nΔU], Z̃max[1:nΔU]
+    foreach(i -> !isinf(ΔUmax[i]) && (i_ΔUmax[i] = false), eachindex(ΔUmax))
+    return i_b
+end 
+
 "Init `i_b` without output & terminal constraints if `NonLinModel` and `SingleShooting`."
 function init_matconstraint_mpc(
-    ::NonLinModel{NT}, ::SingleShooting, nc::Int,
+    ::NonLinModel{NT}, transcription::SingleShooting, Z̃min, Z̃max, nc, nϵ,
     i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
@@ -933,13 +941,15 @@ function init_matconstraint_mpc(
         neq = 0 # number of nonlinear equality constraints
     end
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax]
+    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
+    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
     i_g = [i_Ymin; i_Ymax; i_x̂min;  i_x̂max; trues(nc)]
     return i_b, i_g, A, Aeq, neq
 end
 
 "Init `i_b` without output constraints if `NonLinModel` and other `TranscriptionMethod`."
 function init_matconstraint_mpc(
-    ::NonLinModel{NT}, ::TranscriptionMethod, nc::Int,
+    ::NonLinModel{NT}, transcription::TranscriptionMethod, Z̃min, Z̃max, nc, nϵ,
     i_Umin, i_Umax, i_ΔUmin, i_ΔUmax, i_Ymin, i_Ymax, i_Wmin, i_Wmax, i_x̂min, i_x̂max,
     args...
 ) where {NT<:Real}
@@ -948,13 +958,16 @@ function init_matconstraint_mpc(
     else    
         A_Umin, A_Umax, A_ΔUmin, A_ΔUmax, _ , _ , A_Wmin, A_Wmax, A_x̂min, A_x̂max, Aeq = args
         A   = [A_Umin; A_Umax; A_ΔUmin; A_ΔUmax; A_Wmin; A_Wmax; A_x̂min; A_x̂max]
-        nΔŨ, nZ̃ = size(A_ΔUmin)
-        neq = nZ̃ - nΔŨ - size(Aeq, 1)  # number of nonlinear equality constraints
+        nΔU, nZ̃ = size(A_ΔUmin)
+        nAeq = size(Aeq, 1)             # number of linear equality constraint
+        neq  = nZ̃ - nΔU - nϵ - nAeq     # number of nonlinear equality constraints
     end
     i_b = [i_Umin; i_Umax; i_ΔUmin; i_ΔUmax; i_Wmin; i_Wmax; i_x̂min; i_x̂max]
+    nU, nΔU, nŶ, nW = length(i_Umin), length(i_ΔUmin), length(i_Ymin), length(i_Wmin)
+    i_b = delete_lincon!(i_b,transcription, nU, nΔU, nŶ, nW, Z̃min, Z̃max)
     i_g = [i_Ymin; i_Ymax; trues(nc)]
     return i_b, i_g, A, Aeq, neq
-end
+end 
 
 @doc raw"""
     linconstraint!(mpc::PredictiveController, model::LinModel)
@@ -967,7 +980,7 @@ Also init ``\mathbf{f_x̂} = \mathbf{g_x̂ d_0}(k) + \mathbf{j_x̂ D̂_0} + \mat
 also updated, see [`relaxW`](@ref).
 """
 function linconstraint!(mpc::PredictiveController, model::LinModel, ::TranscriptionMethod)
-    nU, nΔŨ, nY = length(mpc.con.U0min), length(mpc.con.ΔUmin), length(mpc.con.Y0min)
+    nU, nΔU, nY = length(mpc.con.U0min), length(mpc.con.ΔUmin), length(mpc.con.Y0min)
     nW = length(mpc.con.Wmin)
     nx̂, fx̂ = mpc.estim.nx̂, mpc.con.fx̂
     fx̂ .= mpc.con.bx̂
@@ -983,10 +996,10 @@ function linconstraint!(mpc::PredictiveController, model::LinModel, ::Transcript
     n += nU
     mpc.con.b[(n+1):(n+nU)]  .= @. +mpc.con.U0max - mpc.Tu_lastu0
     n += nU
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. -mpc.con.ΔŨmin
-    n += nΔŨ
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. +mpc.con.ΔŨmax
-    n += nΔŨ
+    mpc.con.b[(n+1):(n+nΔU)] .= @. -mpc.con.ΔUmin
+    n += nΔU
+    mpc.con.b[(n+1):(n+nΔU)] .= @. +mpc.con.ΔUmax
+    n += nΔU
     mpc.con.b[(n+1):(n+nY)]  .= @. -mpc.con.Y0min + mpc.F
     n += nY
     mpc.con.b[(n+1):(n+nY)]  .= @. +mpc.con.Y0max - mpc.F
@@ -1007,7 +1020,7 @@ end
 
 "Set `b` excluding predicted output constraints for `NonLinModel` and not `SingleShooting`."
 function linconstraint!(mpc::PredictiveController, model::NonLinModel, ::TranscriptionMethod)
-    nU, nΔŨ = length(mpc.con.U0min), length(mpc.con.ΔŨmin)
+    nU, nΔU = length(mpc.con.U0min), length(mpc.con.ΔUmin)
     nW = length(mpc.con.Wmin)
     nx̂ = mpc.estim.nx̂
     # here, updating fx̂ is not necessary since fx̂ = 0
@@ -1017,10 +1030,10 @@ function linconstraint!(mpc::PredictiveController, model::NonLinModel, ::Transcr
     n += nU
     mpc.con.b[(n+1):(n+nU)]  .= @. +mpc.con.U0max - mpc.Tu_lastu0
     n += nU
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. -mpc.con.ΔŨmin
-    n += nΔŨ
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. +mpc.con.ΔŨmax
-    n += nΔŨ
+    mpc.con.b[(n+1):(n+nΔU)] .= @. -mpc.con.ΔUmin
+    n += nΔU
+    mpc.con.b[(n+1):(n+nΔU)] .= @. +mpc.con.ΔUmax
+    n += nΔU
     mpc.con.b[(n+1):(n+nW)]  .= @. -mpc.con.Wmin + mpc.con.Fw
     n += nW
     mpc.con.b[(n+1):(n+nW)]  .= @. +mpc.con.Wmax - mpc.con.Fw
@@ -1036,7 +1049,7 @@ end
 
 "Also exclude terminal constraints for `NonLinModel` and `SingleShooting`."
 function linconstraint!(mpc::PredictiveController, model::NonLinModel, ::SingleShooting)
-    nU, nΔŨ = length(mpc.con.U0min), length(mpc.con.ΔŨmin)
+    nU, nΔU = length(mpc.con.U0min), length(mpc.con.ΔUmin)
     nW = length(mpc.con.Wmin)
     linconstraint_custom!(mpc, model)
     n = 0
@@ -1044,10 +1057,10 @@ function linconstraint!(mpc::PredictiveController, model::NonLinModel, ::SingleS
     n += nU
     mpc.con.b[(n+1):(n+nU)]  .= @. +mpc.con.U0max - mpc.Tu_lastu0
     n += nU
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. -mpc.con.ΔŨmin
-    n += nΔŨ
-    mpc.con.b[(n+1):(n+nΔŨ)] .= @. +mpc.con.ΔŨmax
-    n += nΔŨ
+    mpc.con.b[(n+1):(n+nΔU)] .= @. -mpc.con.ΔUmin
+    n += nΔU
+    mpc.con.b[(n+1):(n+nΔU)] .= @. +mpc.con.ΔUmax
+    n += nΔU
     mpc.con.b[(n+1):(n+nW)]  .= @. -mpc.con.Wmin + mpc.con.Fw
     n += nW
     mpc.con.b[(n+1):(n+nW)]  .= @. +mpc.con.Wmax - mpc.con.Fw

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -264,8 +264,8 @@ end
     # test default constraints before modifying any:
     @test mpc.con.U0min ≈ fill(-Inf, model.nu)
     @test mpc.con.U0max ≈ fill(Inf, model.nu)
-    @test mpc.con.ΔŨmin ≈ vcat(fill(-Inf, model.nu), 0)
-    @test mpc.con.ΔŨmax ≈ vcat(fill(Inf, model.nu), Inf)
+    @test mpc.con.ΔUmin ≈ fill(-Inf, model.nu)
+    @test mpc.con.ΔUmax ≈ fill(Inf, model.nu)
     @test mpc.con.Y0min ≈ fill(-Inf, model.ny)
     @test mpc.con.Y0max ≈ fill(Inf, model.ny)
     @test mpc.con.Wmin  ≈ fill(-Inf, 2mpc.con.nw)
@@ -274,8 +274,8 @@ end
     @test mpc.con.x̂0max ≈ fill(Inf, mpc.estim.nx̂)
     @test -mpc.con.A_Umin[:, end] ≈ fill(0.0, model.nu)
     @test -mpc.con.A_Umax[:, end] ≈ fill(0.0, model.nu)
-    @test -mpc.con.A_ΔŨmin[1:end-1, end] ≈ fill(0.0, model.nu)
-    @test -mpc.con.A_ΔŨmax[1:end-1, end] ≈ fill(0.0, model.nu)
+    @test -mpc.con.A_ΔUmin[:, end] ≈ fill(0.0, model.nu)
+    @test -mpc.con.A_ΔUmax[:, end] ≈ fill(0.0, model.nu)
     @test -mpc.con.A_Ymin[:, end] ≈ fill(1.0, model.ny)
     @test -mpc.con.A_Ymax[:, end] ≈ fill(1.0, model.ny)
     @test -mpc.con.A_Wmin[:, end] ≈ fill(1.0, 2mpc.con.nw)
@@ -287,8 +287,8 @@ end
     @test mpc.con.U0min ≈ [-5, -9.9]
     @test mpc.con.U0max ≈ [100,99]
     setconstraint!(mpc, Δumin=[-5,-10], Δumax=[6,11])
-    @test mpc.con.ΔŨmin ≈ [-5,-10,0]
-    @test mpc.con.ΔŨmax ≈ [6,11,Inf]
+    @test mpc.con.ΔUmin ≈ [-5,-10]
+    @test mpc.con.ΔUmax ≈ [6,11]
     setconstraint!(mpc, ymin=[-6, -11],ymax=[55, 35])
     @test mpc.con.Y0min ≈ [-6,-11]
     @test mpc.con.Y0max ≈ [55,35]
@@ -303,8 +303,8 @@ end
     @test -mpc.con.A_Umin[:, end] ≈ [0.01,0.02]
     @test -mpc.con.A_Umax[:, end] ≈ [0.03,0.04]
     setconstraint!(mpc, c_Δumin=[0.05,0.06], c_Δumax=[0.07,0.08])
-    @test -mpc.con.A_ΔŨmin[1:end-1, end] ≈ [0.05,0.06]
-    @test -mpc.con.A_ΔŨmax[1:end-1, end] ≈ [0.07,0.08]
+    @test -mpc.con.A_ΔUmin[:, end] ≈ [0.05,0.06]
+    @test -mpc.con.A_ΔUmax[:, end] ≈ [0.07,0.08]
     setconstraint!(mpc, c_ymin=[1.00,1.01], c_ymax=[1.02,1.03])
     @test -mpc.con.A_Ymin[:, end] ≈ [1.00,1.01]
     @test -mpc.con.A_Ymax[:, end] ≈ [1.02,1.03]
@@ -322,8 +322,8 @@ end
     @test mpc2.con.U0min ≈ -1(1:50).-1
     @test mpc2.con.U0max ≈ +1(1:50).+1
     setconstraint!(mpc2, ΔUmin=-1(1:5).-2, ΔUmax=+1(1:5).+2)
-    @test mpc2.con.ΔŨmin ≈ [-1(1:5).-2; 0]
-    @test mpc2.con.ΔŨmax ≈ [+1(1:5).+2; Inf]
+    @test mpc2.con.ΔUmin ≈ -1(1:5).-2
+    @test mpc2.con.ΔUmax ≈ +1(1:5).+2
     setconstraint!(mpc2, Ymin=-1(1:50).-3, Ymax=+1(1:50).+3)
     @test mpc2.con.Y0min ≈ -1(1:50).-3
     @test mpc2.con.Y0max ≈ +1(1:50).+3
@@ -335,8 +335,8 @@ end
     @test -mpc2.con.A_Umin[:, end] ≈ +1(1:50).+5
     @test -mpc2.con.A_Umax[:, end] ≈ +1(1:50).+5
     setconstraint!(mpc2, C_Δumin=+1(1:5).+6, C_Δumax=+1(1:5).+6)
-    @test -mpc2.con.A_ΔŨmin[1:end-1, end] ≈ +1(1:5).+6
-    @test -mpc2.con.A_ΔŨmax[1:end-1, end] ≈ +1(1:5).+6
+    @test -mpc2.con.A_ΔUmin[:, end] ≈ +1(1:5).+6
+    @test -mpc2.con.A_ΔUmax[:, end] ≈ +1(1:5).+6
     setconstraint!(mpc2, C_ymin=+1(1:50).+7, C_ymax=+1(1:50).+7)
     @test -mpc2.con.A_Ymin[:, end] ≈ +1(1:50).+7
     @test -mpc2.con.A_Ymax[:, end] ≈ +1(1:50).+7
@@ -1182,8 +1182,8 @@ end
     @test nmpc.con.U0min ≈ [-5, -9.9]
     @test nmpc.con.U0max ≈ [100,99]
     setconstraint!(nmpc, Δumin=[-5,-10], Δumax=[6,11])
-    @test nmpc.con.ΔŨmin ≈ [-5,-10,0]
-    @test nmpc.con.ΔŨmax ≈ [6,11,Inf]
+    @test nmpc.con.ΔUmin ≈ [-5,-10]
+    @test nmpc.con.ΔUmax ≈ [6,11]
     setconstraint!(nmpc, ymin=[-6, -11],ymax=[55, 35])
     @test nmpc.con.Y0min ≈ [-6,-11]
     @test nmpc.con.Y0max ≈ [55,35]
@@ -1195,8 +1195,8 @@ end
     @test -nmpc.con.A_Umin[:, end] ≈ [0.01,0.02]
     @test -nmpc.con.A_Umax[:, end] ≈ [0.03,0.04]
     setconstraint!(nmpc, c_Δumin=[0.05,0.06], c_Δumax=[0.07,0.08])
-    @test -nmpc.con.A_ΔŨmin[1:end-1, end] ≈ [0.05,0.06]
-    @test -nmpc.con.A_ΔŨmax[1:end-1, end] ≈ [0.07,0.08]
+    @test -nmpc.con.A_ΔUmin[:, end] ≈ [0.05,0.06]
+    @test -nmpc.con.A_ΔUmax[:, end] ≈ [0.07,0.08]
     setconstraint!(nmpc, c_ymin=[1.00,1.01], c_ymax=[1.02,1.03])
     @test -nmpc.con.A_Ymin ≈ zeros(0,3)
     @test -nmpc.con.A_Ymax ≈ zeros(0,3)


### PR DESCRIPTION
Following discussion at #378, it is a good idea in terms of performances to treat constraints on the decision variable as box constraints, instead of linear inequality constraints, at least for NLP and interior point methods.

In this PR, these constraints:
- limit on slack variable $\epsilon \ge 0$
- limits on the input increments $\mathbf{\Delta u}$, 
- limits on the terminal state $\mathbf{\hat{x}}(k+H_p)$ for non-`SingleShooting`
 
are treated as box constraints. It applies to both `LinMPC` and `NonLinMPC`. Note that if there is a nonzero value in the associated softness parameters $\mathbf{c_{(\bullet)}}$ it is no longer a box constraint and the associated bound is treated as a linear inequality constraint, like before.

The default QP solver for `LinMPC` is `OSQP.jl`, and it does not support box constraint natively. It is still possible to define box constraints with the bridge mechanism of `JuMP.jl`. The new default `optim` argument for `LinMPC` is `optim=JuMP.Model(OSQP.MathOptInterfaceOSQP.Optimizer, add_bridges=true)`. It should not affect the performances since JuMP will automatically convert them as linear equality constraints, as it was the case before this PR. It's possible that the performances with `DAQP.jl` will be improved however, since it supports box constraints natively.

> [!WARNING]  
> Constructing `LinMPC` with `optim=JuMP.Model(OSQP.MathOptInterfaceOSQP.Optimizer, add_bridges=false)` will now throw an error. Please use `add_bridges=true` (it should not affect performances).

Let's see the benchmarks.