### PR TITLE
doc: reverting to `Cwt=1e5` for the pendulum in manual

### DIFF
--- a/docs/src/manual/nonlinmpc.md
+++ b/docs/src/manual/nonlinmpc.md
@@ -288,7 +288,7 @@ We construct the controller by enabling relaxation with the `Cwt` argument, and 
 specifying the number of custom inequality constraints `nc`:
 
 ```@example man_nonlin
-Cwt, Pmax, nc = 1e4, 3, Hp+1
+Cwt, Pmax, nc = 1e5, 3, Hp+1
 nmpc2 = NonLinMPC(estim2; Hp, Hc, Nwt=Nwt, Mwt=[0.5, 0], Cwt, gc!, nc, p=Pmax)
 nmpc2 = setconstraint!(nmpc2; umin, umax)
 using JuMP; unset_time_limit_sec(nmpc2.optim) # hide


### PR DESCRIPTION
This is the tuning for this specific solver that leads to no constraint violation. Note that constraint violations are normal and expected if there is modeling mismatch like in this example. But the objective of the manual is to present simple case study. I don't want to enter into the details of constraint violation under plant-model mistmatch here, it is already discussed in the last section for `LinMPC`. Conclusion: let's opt for a tight tuning that suppresses the constraint violation, even if it's not the most robust one.

Related to #384. I kept the `Cwt=1e4` tuning in the benchmark suite.