### PR TITLE
added: pretty-print box constraints

### DIFF
--- a/src/controller/linmpc.jl
+++ b/src/controller/linmpc.jl
@@ -344,8 +344,10 @@ function print_optim_dim(io::IO, mpc::LinMPC)
     nZ̃, nϵ = length(mpc.Z̃), mpc.nϵ
     nA, nW, nAeq = sum(mpc.con.i_b) , mpc.con.nw*(mpc.Hp + 1), size(mpc.con.Aeq, 1)
     m = maximum(ndigits.((nZ̃, nA, nAeq))) + 1
+    i_nZ̃min, i_nZ̃max = @. !isinf(mpc.con.Z̃min), !isinf(mpc.con.Z̃max)
+    nZ̃bounds = sum(i_nZ̃min) + sum(i_nZ̃max)
     println(io, "  └ optimization:")
-    println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nϵ slack variable)")
+    println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nϵ slack variable, $nZ̃bounds bounds)")
     println(io, "    ├$(lpad(nA, m)) linear inequality constraints A ($nW custom)")
     print(io,   "    └$(lpad(nAeq, m)) linear equality constraints Aeq")
 end

--- a/src/controller/nonlinmpc.jl
+++ b/src/controller/nonlinmpc.jl
@@ -1178,8 +1178,10 @@ function print_optim_dim(io::IO, mpc::NonLinMPC)
     nA, nW, nAeq = sum(mpc.con.i_b) , mpc.con.nw*(mpc.Hp + 1), size(mpc.con.Aeq, 1)
     ng, nc, neq = sum(mpc.con.i_g), mpc.con.nc, mpc.con.neq
     m = maximum(ndigits.((nZ̃, nA, nAeq, ng, neq))) + 1
+    i_nZ̃min, i_nZ̃max = @. !isinf(mpc.con.Z̃min), !isinf(mpc.con.Z̃max)
+    nZ̃bounds = sum(i_nZ̃min) + sum(i_nZ̃max)
     println(io, "  └ optimization:")
-    println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nϵ slack variable)")
+    println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nϵ slack variable, $nZ̃bounds bounds)")
     println(io, "    ├$(lpad(nA, m)) linear inequality constraints A ($nW custom)")
     println(io, "    ├$(lpad(nAeq, m)) linear equality constraints Aeq")
     println(io, "    ├$(lpad(ng, m)) nonlinear inequality constraints g ($nc custom)")

--- a/src/estimator/mhe.jl
+++ b/src/estimator/mhe.jl
@@ -38,9 +38,11 @@ function print_estim_dim(io::IO, estim::MovingHorizonEstimator, n; firstchars=no
         nA = sum(estim.con.i_b)
         ng, nc = sum(estim.con.i_g), estim.con.nc 
         m = maximum(ndigits.((nZ̃, nA, ng))) + 1
+        i_nZ̃min, i_nZ̃max = @. !isinf(estim.con.Z̃min), !isinf(estim.con.Z̃max)
+        nZ̃bounds = sum(i_nZ̃min) + sum(i_nZ̃max)
         println(io)
         println(io, "  └ optimization:")
-        println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nε slack variable)")
+        println(io, "    ├$(lpad(nZ̃, m)) decision variables Z̃ ($nε slack variable, $nZ̃bounds bounds)")
         println(io, "    ├$(lpad(nA, m)) linear inequality constraints A")
         print(io,   "    └$(lpad(ng, m)) nonlinear inequality constraints g ($nc custom)")
     end


### PR DESCRIPTION
Before:

```
LinMPC controller with a sample time Ts = 4.0 s:
├ estimator: SteadyKalmanFilter
├ model: LinModel
├ optimizer: OSQP 
├ transcription: MultipleShooting
└ dimensions:
  │ ├ 10 prediction steps Hp
  │ ├  5 control steps Hc
  │ ├  2 manipulated inputs u (0 integrating states)
  │ ├  6 estimated states x̂
  │ ├  2 measured outputs ym (2 integrating states)
  │ ├  0 unmeasured outputs yu
  │ └  1 measured disturbances d
  └ optimization:
    ├ 71 decision variables Z̃ (1 slack variable)
    ├ 40 linear inequality constraints A (0 custom)
    └ 60 linear equality constraints Aeq
```

After:

```
LinMPC controller with a sample time Ts = 4.0 s:
├ estimator: SteadyKalmanFilter
├ model: LinModel
├ optimizer: OSQP 
├ transcription: MultipleShooting
└ dimensions:
  │ ├ 10 prediction steps Hp
  │ ├  5 control steps Hc
  │ ├  2 manipulated inputs u (0 integrating states)
  │ ├  6 estimated states x̂
  │ ├  2 measured outputs ym (2 integrating states)
  │ ├  0 unmeasured outputs yu
  │ └  1 measured disturbances d
  └ optimization:
    ├ 71 decision variables Z̃ (1 slack variable, 21 bounds) # <--- new info
    ├ 40 linear inequality constraints A (0 custom)
    └ 60 linear equality constraints Aeq
```