### PR TITLE
debug: always update linear eq. constraints for `OrthogonalCollocation`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
-version = "2.8.1"
+version = "2.8.2"
 authors = ["Francis Gagnon"]
 
 [deps]

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1280,10 +1280,10 @@ function linconstrainteq!(
     return nothing
 end
 "No linear equality constraints for other cases of [`InternalModel`](@ref)."
-linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel, ::TranscriptionMethod) = nothing
+linconstrainteq!(::PredictiveController, ::NonLinModel, ::InternalModel, ::TranscriptionMethod) = nothing
 "No linear equality constraints for all cases of [`SingleShooting`](@ref) (N/A)."
-linconstrainteq!(::PredictiveController, ::SimModel, ::StateEstimator, ::SingleShooting) = nothing 
-linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel,  ::SingleShooting) = nothing 
+linconstrainteq!(::PredictiveController, ::SimModel,    ::StateEstimator, ::SingleShooting) = nothing 
+linconstrainteq!(::PredictiveController, ::NonLinModel, ::InternalModel,  ::SingleShooting) = nothing 
 
 @doc raw"""
     set_warmstart!(mpc::PredictiveController, ::SingleShooting, Z̃var) -> Z̃s

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1243,10 +1243,11 @@ end
         mpc::PredictiveController, ::SimModel, ::StateEstimator, ::TranscriptionMethod
     )
 
-Do the same for [`SimModel`](@ref), but using simpler equations.
+By default, fallback to doing same the but using the shorter equations.
     
 The linear equality constraints include the stochastic defects only, and the continuity
-constraints of [`OrthogonalCollocation`](@ref), if applicable.
+constraints of [`OrthogonalCollocation`](@ref), if applicable. See [`init_defectmat`](@ref)
+for the equation.
 """
 function linconstrainteq!(
     mpc::PredictiveController, ::SimModel, ::StateEstimator, ::TranscriptionMethod
@@ -1261,7 +1262,7 @@ end
 
 """
     linconstrainteq!(
-        mpc::PredictiveController, ::SimModel, ::InternalModel, ::OrthogonalCollocation
+        mpc::PredictiveController, ::NonLinModel, ::InternalModel, ::OrthogonalCollocation
     )
 
 Same as above but only for the continuity constraints of [`OrthogonalCollocation`](@ref).
@@ -1269,7 +1270,7 @@ Same as above but only for the continuity constraints of [`OrthogonalCollocation
 There are no stochastic defects, the [`InternalModel`](@ref) does not augment the states.
 """
 function linconstrainteq!(
-    mpc::PredictiveController, ::SimModel, ::InternalModel, ::OrthogonalCollocation
+    mpc::PredictiveController, ::NonLinModel, ::InternalModel, ::OrthogonalCollocation
 )
     FS  = mpc.con.FS
     mul!(FS, mpc.con.KS, mpc.estim.x̂0) # the only non-zero matrix is KS
@@ -1280,10 +1281,9 @@ function linconstrainteq!(
 end
 "No linear equality constraints for other cases of [`InternalModel`](@ref)."
 linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel, ::TranscriptionMethod) = nothing
-"No linear equality constraints for all cases of [`SingleShooting`(@ref) (N/A).]"
+"No linear equality constraints for all cases of [`SingleShooting`](@ref) (N/A)."
 linconstrainteq!(::PredictiveController, ::SimModel, ::StateEstimator, ::SingleShooting) = nothing 
-linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel,  ::SingleShooting) = nothing
-linconstrainteq!(::PredictiveController, ::LinModel, ::InternalModel,  ::SingleShooting) = nothing 
+linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel,  ::SingleShooting) = nothing 
 
 @doc raw"""
     set_warmstart!(mpc::PredictiveController, ::SingleShooting, Z̃var) -> Z̃s

--- a/src/controller/transcription.jl
+++ b/src/controller/transcription.jl
@@ -1243,25 +1243,47 @@ end
         mpc::PredictiveController, ::SimModel, ::StateEstimator, ::TranscriptionMethod
     )
 
-Do the same for [`SimModel`](@ref), but using simpler equations (stochastic defects only).
+Do the same for [`SimModel`](@ref), but using simpler equations.
+    
+The linear equality constraints include the stochastic defects only, and the continuity
+constraints of [`OrthogonalCollocation`](@ref), if applicable.
 """
 function linconstrainteq!(
-    mpc::PredictiveController, ::SimModel, estim::StateEstimator, ::TranscriptionMethod
+    mpc::PredictiveController, ::SimModel, ::StateEstimator, ::TranscriptionMethod
 )
-    (estim.nxs < 1) && return nothing # no stochastic state ⟹ no linear eq. constraint
     FS  = mpc.con.FS
-    # the only non-zeros matrices are ES and KS:
-    mul!(FS, mpc.con.KS, mpc.estim.x̂0)
+    mul!(FS, mpc.con.KS, mpc.estim.x̂0) # the only non-zero matrix is KS
     mpc.con.beq .= @. -FS
     linconeq = mpc.optim[:linconstrainteq]
     JuMP.set_normalized_rhs(linconeq, mpc.con.beq)
     return nothing
 end
-"No linear equality constraints for [`InternalModel`](@ref) (state is not augmented)."
-linconstrainteq!(::PredictiveController, ::NonLinModel, ::InternalModel, ::TranscriptionMethod) = nothing
-"No linear equality constraints for [`SingleShooting`(@ref) (N/A).]"
-linconstrainteq!(::PredictiveController, ::SimModel,    ::StateEstimator, ::SingleShooting)  = nothing
-linconstrainteq!(::PredictiveController, ::NonLinModel, ::InternalModel,  ::SingleShooting)  = nothing
+
+"""
+    linconstrainteq!(
+        mpc::PredictiveController, ::SimModel, ::InternalModel, ::OrthogonalCollocation
+    )
+
+Same as above but only for the continuity constraints of [`OrthogonalCollocation`](@ref).
+
+There are no stochastic defects, the [`InternalModel`](@ref) does not augment the states.
+"""
+function linconstrainteq!(
+    mpc::PredictiveController, ::SimModel, ::InternalModel, ::OrthogonalCollocation
+)
+    FS  = mpc.con.FS
+    mul!(FS, mpc.con.KS, mpc.estim.x̂0) # the only non-zero matrix is KS
+    mpc.con.beq .= @. -FS
+    linconeq = mpc.optim[:linconstrainteq]
+    JuMP.set_normalized_rhs(linconeq, mpc.con.beq)
+    return nothing
+end
+"No linear equality constraints for other cases of [`InternalModel`](@ref)."
+linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel, ::TranscriptionMethod) = nothing
+"No linear equality constraints for all cases of [`SingleShooting`(@ref) (N/A).]"
+linconstrainteq!(::PredictiveController, ::SimModel, ::StateEstimator, ::SingleShooting) = nothing 
+linconstrainteq!(::PredictiveController, ::SimModel, ::InternalModel,  ::SingleShooting) = nothing
+linconstrainteq!(::PredictiveController, ::LinModel, ::InternalModel,  ::SingleShooting) = nothing 
 
 @doc raw"""
     set_warmstart!(mpc::PredictiveController, ::SingleShooting, Z̃var) -> Z̃s

--- a/test/3_test_predictive_control.jl
+++ b/test/3_test_predictive_control.jl
@@ -1030,7 +1030,7 @@ end
     @test u ≈ [1.0] atol=5e-2
 
     transcription = TrapezoidalCollocation(1)    
-    nmpc5_1 = NonLinMPC(InternalModel(nonlinmodel_c); Nwt=[0], Hp=100, Hc=1, transcription)
+    nmpc5_1 = NonLinMPC(nonlinmodel_c; Nwt=[0], Hp=100, Hc=1, transcription)
     preparestate!(nmpc5_1, [0.0])
     u = moveinput!(nmpc5_1, [1/0.001])
     @test u ≈ [1.0] atol=5e-2
@@ -1042,10 +1042,13 @@ end
     @test u ≈ [1.0] atol=5e-2
 
     transcription = OrthogonalCollocation(1, roots=:gausslegendre)
-    nmpc6_1 = NonLinMPC(nonlinmodel_c; Nwt=[0], Hp=100, Hc=1, transcription)
+    nmpc6_1 = NonLinMPC(InternalModel(nonlinmodel_c); Nwt=[0], Hp=100, Hc=1, transcription)
     preparestate!(nmpc6_1, [0.0])
     u = moveinput!(nmpc6_1, [1/0.001])
     @test u ≈ [1.0] atol=5e-2
+    setstate!(nmpc6_1, [5.0])
+    moveinput!(nmpc6_1)
+    @test nmpc6_1.con.FS ≈ nmpc6_1.con.KS*nmpc6_1.estim.x̂0 # OC + IMC: special lin. eq. method
     
     nonlinmodel2 = NonLinModel{Float32}(f, h, 3000.0, 1, 2, 1, 1, solver=nothing, p=linmodel2)
     nmpc7  = NonLinMPC(nonlinmodel2, Hp=10)


### PR DESCRIPTION
The right-hand side of the linear equality constraints was not updated with `OrthogonalCollocation` in these two cases :

1) with `estim::InternalModel`
2) with `nint_ym=0` and `nint_u=0` options

It should be always updated with this transcription method. This is a bugfix.