### PR TITLE
test: improve coverage of `MovingHorizonEstimator` with `MultipleShooting` transcription

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
-version = "2.9.0"
+version = "2.9.1"
 authors = ["Francis Gagnon"]
 
 [deps]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,7 @@
 # ModelPredictiveControl.jl
 
 An open source [model predictive control](https://en.wikipedia.org/wiki/Model_predictive_control)
+and [moving horizon estimation](https://en.wikipedia.org/wiki/Moving_horizon_estimation)
 package for Julia.
 
 The package depends on [`ControlSystemsBase.jl`](https://github.com/JuliaControl/ControlSystems.jl)

--- a/src/estimator/mhe/construct.jl
+++ b/src/estimator/mhe/construct.jl
@@ -247,10 +247,10 @@ It can handle constraints on the estimates. Additionally, `model` is not lineari
 the [`UnscentedKalmanFilter`](@ref). The computational costs are drastically higher, 
 however, since it minimizes the following objective function at each discrete time ``k``:
 ```math
-\min_{\mathbf{x̂}_k(k-N_k+p), \mathbf{Ŵ}, ε}   \mathbf{x̄}' \mathbf{P̄}^{-1}       \mathbf{x̄} 
-                                            + \mathbf{Ŵ}' \mathbf{Q̂}_{N_k}^{-1} \mathbf{Ŵ}  
-                                            + \mathbf{V̂}' \mathbf{R̂}_{N_k}^{-1} \mathbf{V̂}
-                                            + C ε^2
+\min_{\mathbf{Z}, ε}   \mathbf{x̄}' \mathbf{P̄}^{-1}       \mathbf{x̄} 
+                     + \mathbf{Ŵ}' \mathbf{Q̂}_{N_k}^{-1} \mathbf{Ŵ}  
+                     + \mathbf{V̂}' \mathbf{R̂}_{N_k}^{-1} \mathbf{V̂}
+                     + C ε^2
 ```
 subject to [`setconstraint!`](@ref) bounds and the custom nonlinear inequality constraints:
 ```math
@@ -276,13 +276,15 @@ N_k =                     \begin{cases}
     k + 1   &  k < H_e    \\
     H_e     &  k ≥ H_e    \end{cases}
 ```
-The vectors ``\mathbf{Ŵ}`` and ``\mathbf{V̂}`` respectively encompass the estimated process
-noises ``\mathbf{ŵ}(k-j+p)`` and sensor noises ``\mathbf{v̂}(k-j+1)`` from ``j=N_k`` to ``1``.
-The arguments of ``\mathbf{g_c}`` include the extended vectors of the estimated states 
-``\mathbf{X̂_e}``, estimated sensor noises ``\mathbf{V̂_e}``,  estimated process noises
-``\mathbf{Ŵ_e}``, manipulated inputs ``\mathbf{U_e}``, measured outputs ``\mathbf{Y_e^m}``
-and measured disturbances ``\mathbf{D_e}``. The Extended Help details all these vectors, the
-slack variable ``ε`` and the estimation of the covariance at arrival 
+The chosen [`TranscriptionMethod`](@ref) determines the content of the decision vector
+``\mathbf{Z}`` (default to [`SingleShooting`](@ref), hence both ``\mathbf{x̂}_k(k-N_k+p)``
+and ``\mathbf{Ŵ}``). The vectors ``\mathbf{Ŵ}`` and ``\mathbf{V̂}`` respectively encompass 
+the estimated process noises ``\mathbf{ŵ}(k-j+p)`` and sensor noises ``\mathbf{v̂}(k-j+1)``
+from ``j=N_k`` to ``1``. The arguments of ``\mathbf{g_c}`` include the extended vectors of
+the estimated states ``\mathbf{X̂_e}``, estimated sensor noises ``\mathbf{V̂_e}``,  estimated
+process noises ``\mathbf{Ŵ_e}``, manipulated inputs ``\mathbf{U_e}``, measured outputs 
+``\mathbf{Y_e^m}`` and measured disturbances ``\mathbf{D_e}``. The Extended Help details all
+these vectors, the slack variable ``ε`` and the estimation of the covariance at arrival 
 ``\mathbf{P̂}_{k-N_k}(k-N_k+p)``. If the keyword argument `direct=true` (default value), the
 constant ``p=0`` in the equations above, and the MHE is in the current form. Else ``p=1``,
 leading to the prediction form.

--- a/src/transcription.jl
+++ b/src/transcription.jl
@@ -87,6 +87,7 @@ Sparse optimizers like `OSQP` or `Ipopt` and sparse Jacobian computations are re
 for this transcription method. The transcription of [`MovingHorizonEstimator`](@ref) is
 provided in the Extended Help.
 
+# Extended Help
 !!! details "Extended Help"
     For [`MovingHorizonEstimator`](@ref), the decision variable is (excluding slack `ε`):
     ```math

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1215,7 +1215,11 @@ end
     end
     @test mhe1c([5]) ≈ [51, 32] atol=1e-3
 
-    mhe2 = MovingHorizonEstimator(nonlinmodel, He=3, transcription=MultipleShooting())
+    gc!(gc, args...) = (gc[1] = 0) #for coverage only
+    mhe2 = MovingHorizonEstimator(
+        nonlinmodel, He=3, transcription=MultipleShooting(), gc! = gc!, nc = 1
+    )
+    mhe2 = setconstraint!(mhe2, v̂min = [-1000, -1000], v̂max = [1000, 1000]) # for coverage only
     for i in 1:40
         preparestate!(mhe2, [50, 30], [5])
         updatestate!(mhe2, [11, 52], [50, 30], [5])

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1151,7 +1151,7 @@ end
     nonlinmodel = NonLinModel(f, h, Ts, 2, 4, 2, 1, solver=nothing, p=linmodel)
     nonlinmodel = setop!(nonlinmodel, uop=[10,50], yop=[50,30], dop=[5])
 
-    mhe1 = MovingHorizonEstimator(nonlinmodel, He=2)
+    mhe1 = MovingHorizonEstimator(nonlinmodel, He=3)
     JuMP.set_attribute(mhe1.optim, "tol", 1e-7)
     preparestate!(mhe1, [50, 30], [5])
     x̂ = updatestate!(mhe1, [10, 50], [50, 30], [5])
@@ -1215,7 +1215,7 @@ end
     end
     @test mhe1c([5]) ≈ [51, 32] atol=1e-3
 
-    mhe2 = MovingHorizonEstimator(nonlinmodel, He=2, transcription=MultipleShooting())
+    mhe2 = MovingHorizonEstimator(nonlinmodel, He=3, transcription=MultipleShooting())
     for i in 1:40
         preparestate!(mhe2, [50, 30], [5])
         updatestate!(mhe2, [11, 52], [50, 30], [5])
@@ -1223,7 +1223,9 @@ end
     preparestate!(mhe2, [50, 30], [5])
     @test mhe2([5]) ≈ [50, 30] atol=1e-3
 
-    mhe3 = MovingHorizonEstimator(nonlinmodel, He=2, transcription=MultipleShooting(f_threads=true))
+    mhe3 = MovingHorizonEstimator(
+        nonlinmodel, He=3, direct=false, transcription=MultipleShooting(f_threads=true)
+    )
     for i in 1:40
         preparestate!(mhe3, [50, 30], [5])
         updatestate!(mhe3, [11, 52], [50, 30], [5])

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1413,6 +1413,11 @@ end
     @test mhe3.con.C_v̂min ≈ 0.03(11:18)
     @test mhe3.con.C_v̂max ≈ 0.04(11:18)
 
+    mhe4 = MovingHorizonEstimator(nonlinmodel, He=4, nint_ym=0, transcription=MultipleShooting())
+    setconstraint!(mhe4, X̂min=-0.1(1:10), X̂max=0.1(1:10))
+    @test mhe4.con.Z̃min[1:10] ≈ -0.1(1:10)
+    @test mhe4.con.Z̃max[1:10] ≈  0.1(1:10)
+
     @test_throws DimensionMismatch setconstraint!(mhe2, x̂min=[-1])
     @test_throws DimensionMismatch setconstraint!(mhe2, x̂max=[+1])
     @test_throws DimensionMismatch setconstraint!(mhe2, ŵmin=[-1])


### PR DESCRIPTION
It also improves `MovingHorizonEstimator` docstring. The decision variable is now $\mathbf{Z}, \varepsilon$, instead of the fixed single shooting formulation.