### PR TITLE
debug: reset `prepared` flag in `initstate!(::StateEstimator)` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
-version = "2.9.1"
+version = "2.9.2"
 authors = ["Francis Gagnon"]
 
 [deps]

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -182,6 +182,7 @@ function initstate!(estim::StateEstimator, u, ym, d=estim.buffer.empty)
     init_estimate!(estim, estim.model, y0m, d0, u0)
     # --- init covariance error estimate, if applicable ---
     init_estimate_cov!(estim, y0m, d0, u0)
+    estim.prepared[] = false
     x̂ = estim.x̂0 + estim.x̂op
     return x̂
 end

--- a/src/estimator/execute.jl
+++ b/src/estimator/execute.jl
@@ -183,7 +183,8 @@ function initstate!(estim::StateEstimator, u, ym, d=estim.buffer.empty)
     # --- init covariance error estimate, if applicable ---
     init_estimate_cov!(estim, y0m, d0, u0)
     estim.prepared[] = false
-    x̂ = estim.x̂0 + estim.x̂op
+    x̂  = estim.buffer.x̂
+    x̂ .= estim.x̂0 .+ estim.x̂op
     return x̂
 end
 

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -75,6 +75,7 @@ end
     @test evaloutput(kalmanfilter1) ≈ kalmanfilter1() ≈ [50, 30]
     @test evaloutput(kalmanfilter1, d) ≈ kalmanfilter1(d) ≈ [50, 30]
     @test initstate!(kalmanfilter1, [10, 50], [50, 30+1]) ≈ [zeros(3); [1]]
+    @test kalmanfilter1.prepared[] == false
     linmodel2 = LinModel(append(tf(1, [1, 0]), tf(2, [10, 1])), 1.0)
     kalmanfilter2 = SteadyKalmanFilter(linmodel2, nint_u=[1, 1], direct=false)
     x = initstate!(kalmanfilter2, [10, 3], [0.5, 6+0.1])


### PR DESCRIPTION
This is a minor debug to ensure that the user does not call `updatestate!` w/o `preparestate!` when `direct==true` just after calling `initstate!` on a `StateEstimator` (or a `PredictiveController`). By resetting the flag, an error will be thrown in such cases, as it should be to guide the user.