### PR TITLE
debug: update defect matrices in `setmodel!` for `MovingHorizonEstimator` and `LinModel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelPredictiveControl"
 uuid = "61f9bdb8-6ae4-484a-811f-bbf86720c31c"
-version = "2.9.2"
+version = "2.9.3"
 authors = ["Francis Gagnon"]
 
 [deps]

--- a/src/controller/execute.jl
+++ b/src/controller/execute.jl
@@ -770,7 +770,7 @@ function setmodel_controller!(mpc::PredictiveController, uop_old, x̂op_old)
     ]
     # --- linear equality constraints ---
     con.Aeq .= Aeq
-    # --- operating points ---
+    # --- bound constraint operating points ---
     con.U0min .+= mpc.Uop # convert U0 to U with the old operating point
     con.U0max .+= mpc.Uop # convert U0 to U with the old operating point
     con.Y0min .+= mpc.Yop # convert Y0 to Y with the old operating point

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -1009,6 +1009,9 @@ function setmodel_estimator!(
     JuMP.delete(estim.optim, estim.optim[:linconstraint])
     JuMP.unregister(estim.optim, :linconstraint)
     @constraint(estim.optim, linconstraint, A*Z̃var .≤ b)
+    JuMP.delete(estim.optim, estim.optim[:linconstrainteq])
+    JuMP.unregister(estim.optim, :linconstrainteq)
+    @constraint(optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)
     for i in eachindex(Z̃var)
         # deletion not required here since changing op. pts won't change finite status
         !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -1011,7 +1011,7 @@ function setmodel_estimator!(
     @constraint(estim.optim, linconstraint, A*Z̃var .≤ b)
     JuMP.delete(estim.optim, estim.optim[:linconstrainteq])
     JuMP.unregister(estim.optim, :linconstrainteq)
-    @constraint(optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)
+    @constraint(estim.optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)
     for i in eachindex(Z̃var)
         # deletion not required here since changing op. pts won't change finite status
         !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -924,26 +924,22 @@ function setmodel_estimator!(
     estim.G .= G
     estim.J .= J
     estim.B .= B
-    # --- linear inequality constraints ---
+    # --- state estimate constraints ---
     con.ẼX̂ .= ẼX̂
     con.GX̂ .= GX̂
     con.JX̂ .= JX̂
     con.BX̂ .= BX̂
-    # convert x̂0 to x̂ with the old operating point:
-    con.x̂0min .+= x̂op_old 
-    con.x̂0max .+= x̂op_old
-    # convert X̂0 to X̂ with the old operating point:
-    con.X̂0min .+= estim.X̂op
-    con.X̂0max .+= estim.X̂op
-    for i in 0:He-1
-        estim.X̂op[(1+nx̂*i):(nx̂+nx̂*i)] .= estim.x̂op
-    end
-    # convert x̂ to x̂0 with the new operating point:
-    con.x̂0min .-= estim.x̂op 
-    con.x̂0max .-= estim.x̂op 
-    # convert X̂ to X̂0 with the new operating point:
-    con.X̂0min .-= estim.X̂op
-    con.X̂0max .-= estim.X̂op
+    # --- defect matrices ---
+    ES, GS, JS, BS = init_defectmat_mhe(
+        model, transcription, He, estim.Â, estim.B̂u, estim.B̂d, estim.x̂op, estim.f̂op, 
+        estim.direct
+    )
+    Aeq, ẼS = augmentdefect(ES, nε; slackfirst=true)
+    con.ẼS .= ẼS
+    con.GS .= GS
+    con.JS .= JS
+    con.BS .= BS
+    # --- linear inequality constraints ---
     con.A_X̂min .= A_X̂min
     con.A_X̂max .= A_X̂max
     con.A_V̂min .= A_V̂min
@@ -958,26 +954,21 @@ function setmodel_estimator!(
         con.A_V̂min
         con.A_V̂max
     ]
-    Z̃min, Z̃max = init_boxconstraint_mhe(
-        model, transcription, He, nx̂, nŵ, nε,
-        con.x̂0min,  con.x̂0max,  con.X̂0min,  con.X̂0max,  con.Ŵmin,   con.Ŵmax, 
-        con.A_x̂min, con.A_x̂max, con.C_x̂min, con.C_x̂max, con.A_Ŵmin, con.A_Ŵmax 
-    )
-    con.Z̃min .= Z̃min
-    con.Z̃max .= Z̃max
-    Z̃var::Vector{JuMP.VariableRef} = estim.optim[:Z̃var]
-    A = con.A[con.i_b, :]
-    b = zeros(count(con.i_b)) # dummy value, updated before optimization (avoid ±Inf)
-    # deletion is required for sparse solvers like OSQP, when the sparsity pattern changes
-    JuMP.delete(estim.optim, estim.optim[:linconstraint])
-    JuMP.unregister(estim.optim, :linconstraint)
-    @constraint(estim.optim, linconstraint, A*Z̃var .≤ b)
-    for i in eachindex(Z̃var)
-        # deletion not required here since changing op. pts won't change finite status
-        !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])
-        !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i])
+    # --- linear equality constraints ---
+    con.Aeq .= Aeq
+    # --- bound constraint operating points ---
+    con.x̂0min .+= x̂op_old   # convert x̂0 to x̂ with the old operating point
+    con.x̂0max .+= x̂op_old   # convert x̂0 to x̂ with the old operating point
+    con.X̂0min .+= estim.X̂op # convert X̂0 to X̂ with the old operating point
+    con.X̂0max .+= estim.X̂op # convert X̂0 to X̂ with the old operating point
+    for i in 0:He-1
+        estim.X̂op[(1+nx̂*i):(nx̂+nx̂*i)] .= estim.x̂op
     end
-    # --- data windows ---
+    con.x̂0min .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
+    con.x̂0max .-= estim.x̂op # convert x̂ to x̂0 with the new operating point
+    con.X̂0min .-= estim.X̂op # convert X̂ to X̂0 with the new operating point
+    con.X̂0max .-= estim.X̂op # convert X̂ to X̂0 with the new operating point
+    # --- data windows operating points ---
     for i in 1:He 
         # convert y0m to ym with the old operating point:
         estim.Y0m[(1+nym*(i-1)):(nym*i)]  .+= @views yop_old[estim.i_ym]
@@ -1002,6 +993,27 @@ function setmodel_estimator!(
     estim.lastu0        .-= model.uop
     estim.Z̃[nε+1:nε+nx̂] .-= x̂op
     estim.x̂0arr_old     .-= x̂op
+    # --- box constraints ---
+    Z̃min, Z̃max = init_boxconstraint_mhe(
+        model, transcription, He, nx̂, nŵ, nε,
+        con.x̂0min,  con.x̂0max,  con.X̂0min,  con.X̂0max,  con.Ŵmin,   con.Ŵmax, 
+        con.A_x̂min, con.A_x̂max, con.C_x̂min, con.C_x̂max, con.A_Ŵmin, con.A_Ŵmax 
+    )
+    con.Z̃min .= Z̃min
+    con.Z̃max .= Z̃max
+    # --- JuMP optimization ---
+    Z̃var::Vector{JuMP.VariableRef} = estim.optim[:Z̃var]
+    A = con.A[con.i_b, :]
+    b = zeros(count(con.i_b)) # dummy value, updated before optimization (avoid ±Inf)
+    # deletion is required for sparse solvers like OSQP, when the sparsity pattern changes
+    JuMP.delete(estim.optim, estim.optim[:linconstraint])
+    JuMP.unregister(estim.optim, :linconstraint)
+    @constraint(estim.optim, linconstraint, A*Z̃var .≤ b)
+    for i in eachindex(Z̃var)
+        # deletion not required here since changing op. pts won't change finite status
+        !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])
+        !isinf(Z̃max[i]) && JuMP.set_upper_bound(Z̃var[i], Z̃max[i])
+    end
     # --- covariance matrices ---
     if !isnothing(Q̂)
         estim.cov.Q̂ .= to_hermitian(Q̂)

--- a/src/estimator/mhe/execute.jl
+++ b/src/estimator/mhe/execute.jl
@@ -1009,9 +1009,11 @@ function setmodel_estimator!(
     JuMP.delete(estim.optim, estim.optim[:linconstraint])
     JuMP.unregister(estim.optim, :linconstraint)
     @constraint(estim.optim, linconstraint, A*Z̃var .≤ b)
-    JuMP.delete(estim.optim, estim.optim[:linconstrainteq])
-    JuMP.unregister(estim.optim, :linconstrainteq)
-    @constraint(estim.optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)
+    if haskey(estim.optim, :linconstrainteq) # the key will be absent when Nk < He
+        JuMP.delete(estim.optim, estim.optim[:linconstrainteq])
+        JuMP.unregister(estim.optim, :linconstrainteq)
+        @constraint(estim.optim, linconstrainteq, con.Aeq*Z̃var .== con.beq)
+    end
     for i in eachindex(Z̃var)
         # deletion not required here since changing op. pts won't change finite status
         !isinf(Z̃min[i]) && JuMP.set_lower_bound(Z̃var[i], Z̃min[i])

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1641,7 +1641,7 @@ end
 
 @testitem "MHE set model" setup=[SetupMPCtests] begin
     using .SetupMPCtests, ControlSystemsBase, LinearAlgebra
-    linmodel = LinModel(ss(0.5, 0.3, 1.0, 0, 10.0))
+    linmodel = LinModel([0.5], [0.3], [1.0], 0, 0, 10.0)
     linmodel = setop!(linmodel, uop=[2.0], yop=[50.0], xop=[3.0], fop=[3.0])
     He = 5
     mhe = MovingHorizonEstimator(linmodel; He, nint_ym=0, direct=false)
@@ -1651,7 +1651,7 @@ end
     preparestate!(mhe, [50.0])
     x̂ = updatestate!(mhe, [2.0], [50.0])
     @test x̂ ≈ [3.0]
-    newlinmodel = LinModel(ss(0.2, 0.3, 1.0, 0, 10.0))
+    newlinmodel = LinModel([0.2], [0.3], [1.0], 0, 0, 10.0)
     newlinmodel = setop!(newlinmodel, uop=[3.0], yop=[55.0], xop=[3.0], fop=[3.0])
     setmodel!(mhe, newlinmodel)
     @test mhe.Â ≈ [0.2]
@@ -1676,6 +1676,7 @@ end
     @test mhe.cov.invQ̂_He ≈ diagm(repeat([1e3], He))
     @test mhe.cov.R̂ ≈ [1e-6]
     @test mhe.cov.invR̂_He ≈ diagm(repeat([1e6], He))
+
     f(x,u,d,model) = model.A*x + model.Bu*u + model.Bd*d
     h(x,d,model)   = model.C*x + model.Du*d
     nonlinmodel = NonLinModel(f, h, 10.0, 1, 1, 1, p=linmodel, solver=nothing)
@@ -1685,9 +1686,25 @@ end
     @test mhe2.cov.invQ̂_He ≈ diagm(repeat([1e3], He))
     @test mhe2.cov.R̂ ≈ [1e-6]
     @test mhe2.cov.invR̂_He ≈ diagm(repeat([1e6], He))
+
+    linmodel = LinModel([0.5], [0.3], [1.0], 0, 0, 10.0)
+    linmodel = setop!(linmodel, uop=[2.0], yop=[50.0], xop=[3.0], fop=[3.0])
+    mhe3 = MovingHorizonEstimator(
+        linmodel; He, nint_ym=0, direct=false, transcription=MultipleShooting()
+    )
+    x̂ = updatestate!(mhe3, [2.0 + 1.0], [50.0])
+    @test x̂ ≈ [3.0 + 0.3] atol=1e-3
+    newlinmodel = LinModel([0.5], [0.9], [1.0], 0, 0, 10.0)
+    newlinmodel = setop!(newlinmodel, uop=[3.0], yop=[55.0], xop=[8.0], fop=[8.0])
+    setmodel!(mhe3, newlinmodel)
+    initstate!(mhe3, [3.0], [55.0])
+    x̂ = updatestate!(mhe3, [3.0 + 1.0], [55.0])
+    @test x̂ ≈ [8.0 + 0.9] atol=1e-3
+    
     @test_throws ErrorException setmodel!(mhe2, deepcopy(nonlinmodel))
     @test_throws ErrorException setmodel!(mhe, Q̂=diagm([-0.1]))
-    @test_throws ErrorException setmodel!(mhe, R̂=diagm([-0.1]))
+    @test_throws ErrorException setmodel!(mhe, R̂=diagm([-0.1]))=#
+
 end
 
 @testitem "MHE v.s. Kalman filters" setup=[SetupMPCtests] begin

--- a/test/2_test_state_estim.jl
+++ b/test/2_test_state_estim.jl
@@ -1677,15 +1677,19 @@ end
     @test mhe.cov.R̂ ≈ [1e-6]
     @test mhe.cov.invR̂_He ≈ diagm(repeat([1e6], He))
 
-    f(x,u,d,model) = model.A*x + model.Bu*u + model.Bd*d
-    h(x,d,model)   = model.C*x + model.Du*d
-    nonlinmodel = NonLinModel(f, h, 10.0, 1, 1, 1, p=linmodel, solver=nothing)
-    mhe2 = MovingHorizonEstimator(nonlinmodel; He, nint_ym=0)
-    setmodel!(mhe2, Q̂=[1e-3], R̂=[1e-6])
-    @test mhe2.cov.Q̂ ≈ [1e-3]
-    @test mhe2.cov.invQ̂_He ≈ diagm(repeat([1e3], He))
-    @test mhe2.cov.R̂ ≈ [1e-6]
-    @test mhe2.cov.invR̂_He ≈ diagm(repeat([1e6], He))
+    linmodel = LinModel([0.5], [0.3], [1.0], 0, 0, 10.0)
+    linmodel = setop!(linmodel, uop=[2.0], yop=[50.0], xop=[3.0], fop=[3.0])
+    mhe2 = MovingHorizonEstimator(
+        linmodel; He, nint_ym=0, direct=false, transcription=SingleShooting()
+    )
+    x̂ = updatestate!(mhe2, [2.0 + 1.0], [50.0])
+    @test x̂ ≈ [3.0 + 0.3] atol=1e-3
+    newlinmodel = LinModel([0.5], [0.9], [1.0], 0, 0, 10.0)
+    newlinmodel = setop!(newlinmodel, uop=[3.0], yop=[55.0], xop=[8.0], fop=[8.0])
+    setmodel!(mhe2, newlinmodel)
+    initstate!(mhe2, [3.0], [55.0])
+    x̂ = updatestate!(mhe2, [3.0 + 1.0], [55.0])
+    @test x̂ ≈ [8.0 + 0.9] atol=1e-3
 
     linmodel = LinModel([0.5], [0.3], [1.0], 0, 0, 10.0)
     linmodel = setop!(linmodel, uop=[2.0], yop=[50.0], xop=[3.0], fop=[3.0])
@@ -1700,10 +1704,20 @@ end
     initstate!(mhe3, [3.0], [55.0])
     x̂ = updatestate!(mhe3, [3.0 + 1.0], [55.0])
     @test x̂ ≈ [8.0 + 0.9] atol=1e-3
+
+    f(x,u,d,model) = model.A*x + model.Bu*u + model.Bd*d
+    h(x,d,model)   = model.C*x + model.Du*d
+    nonlinmodel = NonLinModel(f, h, 10.0, 1, 1, 1, p=linmodel, solver=nothing)
+    mhe5 = MovingHorizonEstimator(nonlinmodel; He, nint_ym=0)
+    setmodel!(mhe5, Q̂=[1e-3], R̂=[1e-6])
+    @test mhe5.cov.Q̂ ≈ [1e-3]
+    @test mhe5.cov.invQ̂_He ≈ diagm(repeat([1e3], He))
+    @test mhe5.cov.R̂ ≈ [1e-6]
+    @test mhe5.cov.invR̂_He ≈ diagm(repeat([1e6], He))
     
-    @test_throws ErrorException setmodel!(mhe2, deepcopy(nonlinmodel))
+    @test_throws ErrorException setmodel!(mhe5, deepcopy(nonlinmodel))
     @test_throws ErrorException setmodel!(mhe, Q̂=diagm([-0.1]))
-    @test_throws ErrorException setmodel!(mhe, R̂=diagm([-0.1]))=#
+    @test_throws ErrorException setmodel!(mhe, R̂=diagm([-0.1]))
 
 end
 


### PR DESCRIPTION
I forgot to re-construct the defect matrices when calling `setmodel(estim::MovingHorizonEstimator, newmodel::LinModel)`. I added new tests to verify this.